### PR TITLE
misc: Allow bmpflash to be built with MSVC

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -88,10 +88,19 @@ bmpflashSrc = [
 
 subdir('elf')
 
+bmpflashCppArgs = ['-D_FORTIFY_SOURCE=2']
+if host_machine.system() == 'windows'
+	# libusb includes an unguarded windows.h header.
+	bmpflashCppArgs += [
+		'-DNOMINMAX',
+		'-DWIN32_LEAN_AND_MEAN',
+	]
+endif
+
 bmpflash = executable(
 	'bmpflash',
 	bmpflashSrc,
-	cpp_args: ['-D_FORTIFY_SOURCE=2'],
+	cpp_args: bmpflashCppArgs,
 	include_directories: [include_directories('include', 'include/elf')],
 	dependencies: [substrate, fmt, libusb],
 	gnu_symbol_visibility: 'inlineshidden'


### PR DESCRIPTION
Hi all!

This is a MR to allow you to build bmpflash under Microsoft Visual Studio. The sole issue is that libusb includes windows.h unguarded, which in turns breaks substrate because of the `min()` and `max()` macros trumping `std::numeric_limits`.

Since there are many places where libusb.h is included, I have chosen to add the relevant macros at the setup stage instead.

Let me know what you think.