### PR TITLE
misc: Turn on several equivalent warnings in MSVC

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,9 @@ project(
 		'buildtype=release',
 		'strip=true',
 		'b_debug=if-release',
-		'b_lto=true'
+		'b_lto=true',
+ 		# libusb needs to pass functions to/from C++ land
+		'cpp_eh=s',
 	],
 	version: '0.0.1',
 	meson_version: '>= 0.63',

--- a/src/meson.build
+++ b/src/meson.build
@@ -68,16 +68,16 @@ extendedWarnings = [
 	# -Wno-inline
 	'-wd4710', # 'identifier': function not inlined
 	'-wd4711', # function 'identifier' selected for automatic inline expansion
+	'-wd4514', # 'identifier': unreferenced inline function has been removed
 
 	# -Wunused
-	'-w34514', # 'identifier': unreferenced inline function has been removed
 	'-w35264', # 'identifier': 'const' variable is not used
 
 	# -Wundef
 	'-w34668', # '___cplusplus' is not defined as a preprocessor macro, replacing with '0' for '#if/#elif''
 
 	# -Wpacked -- disabling because MSVC uses pragmas for packing
-	'-w34820', # 'identifier': 'X' bytes padding added after data member 'identifier'
+	'-wd4820', # 'identifier': 'X' bytes padding added after data member 'identifier'
 
 	# -Wignored-qualifiers
 	'-w35266', # 'const' qualifier on return type has no effect
@@ -89,11 +89,11 @@ extendedWarnings = [
 	'-w34061', # enumerator 'identifier' in switch of enum 'identifier' is not explicitly handled by a case label
 
 	# -Wdefaulted-function-deleted
-	'-w34625', # 'identifier': copy constructor was implicitly defined as deleted
-	'-w34626', # 'identifier': assignment operator was implicitly defined as deleted
-	'-w34623', # 'identifier': default constructor was implicitly defined as deleted
-	'-w35026', # 'identifier': move constructor was implicitly defined as deleted
-	'-w35027', # 'identifier': move assignment operator was implicitly defined as deleted
+	'-wd4625', # 'identifier': copy constructor was implicitly defined as deleted
+	'-wd4626', # 'identifier': assignment operator was implicitly defined as deleted
+	'-wd4623', # 'identifier': default constructor was implicitly defined as deleted
+	'-wd5026', # 'identifier': move constructor was implicitly defined as deleted
+	'-wd5027', # 'identifier': move assignment operator was implicitly defined as deleted
 
 	# -Wdeprecated(-copy)
 	'-w35267', # definition of implicit copy constructor for 'identifier' is deprecated because it has a user-provided destructor'

--- a/src/meson.build
+++ b/src/meson.build
@@ -44,6 +44,62 @@ extendedWarnings = [
 	'-Wstack-protector',
 	'-Wunsuffixed-float-constant',
 	'-Wimplicit-fallthrough',
+	'-Wundef',
+	'-Wignored-qualifiers',
+	'-Wshadow',
+	'-Wswitch-enum',
+	'-Wdefaulted-function-deleted',
+	'-Wdeprecated-copy',
+
+	# MSVC unique warnings that are useful
+	'-w35030', # attribute 'gnu::packed' is not recognized
+	'-w35039', # 'identifier': pointer or reference to potentially throwing function passed to 'extern "C"' function under -EHc. Undefined behavior may occur if this function throws an exception.
+	'-w35045', # Compiler will insert Spectre mitigation for memory load if /Qspectre switch specified
+
+	# -Wmaybe-uninitialized -- UB
+	'-w34355', # 'this': used in base member initializer list
+
+	# -Wconversion
+	'-w34242', # 'initializing': conversion from '_Ty' to '_Ty1', possible loss of data
+	'-w34244', # 'return': conversion from '_Ty' to '_Ty1', possible loss of data
+	'-w34365', # 'identifier': conversion from 'identifier' to 'identifier', signed/unsigned mismatch
+	'-w34800', # Implicit conversion from 'identifier' to bool. Possible information loss
+
+	# -Wno-inline
+	'-wd4710', # 'identifier': function not inlined
+	'-wd4711', # function 'identifier' selected for automatic inline expansion
+
+	# -Wunused
+	'-w34514', # 'identifier': unreferenced inline function has been removed
+	'-w35264', # 'identifier': 'const' variable is not used
+
+	# -Wundef
+	'-w34668', # '___cplusplus' is not defined as a preprocessor macro, replacing with '0' for '#if/#elif''
+
+	# -Wpacked -- disabling because MSVC uses pragmas for packing
+	'-w34820', # 'identifier': 'X' bytes padding added after data member 'identifier'
+
+	# -Wignored-qualifiers
+	'-w35266', # 'const' qualifier on return type has no effect
+
+	# -Wshadow
+	'-w34458', # declaration of 'device' hides class member
+
+	# -Wswitch-enum
+	'-w34061', # enumerator 'identifier' in switch of enum 'identifier' is not explicitly handled by a case label
+
+	# -Wdefaulted-function-deleted
+	'-w34625', # 'identifier': copy constructor was implicitly defined as deleted
+	'-w34626', # 'identifier': assignment operator was implicitly defined as deleted
+	'-w34623', # 'identifier': default constructor was implicitly defined as deleted
+	'-w35026', # 'identifier': move constructor was implicitly defined as deleted
+	'-w35027', # 'identifier': move assignment operator was implicitly defined as deleted
+
+	# -Wdeprecated(-copy)
+	'-w35267', # definition of implicit copy constructor for 'identifier' is deprecated because it has a user-provided destructor'
+
+	# Undocumented
+	'-wd4582', # 'identifier': constructor is not implicitly called
 ]
 
 add_project_arguments(


### PR DESCRIPTION
Hey,

This is a PR to apply some equivalent (and possibly performance related) warnings coming from MSVC when `-Dwarning_level=everything` is used.