### PR TITLE
Feature: Cleaner Windows builds

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,29 @@
+---
+Checks: 'bugprone-*,cert-*,clang-analyzer-*,misc-*,modernize-*,portability-*,performance-*,readability-*,-readability-magic-numbers,-readability-braces-around-statements,-modernize-use-trailing-return-type,-readability-named-parameter,-readability-implicit-bool-conversion,-bugprone-easily-swappable-parameters'
+FormatStyle: 'none'
+HeaderFilterRegex: '(src)/.+'
+AnalyzeTemporaryDtors: false
+CheckOptions:
+  - key:   cert-dcl16-c.NewSuffixes
+    value: 'L;LL;UL;ULL'
+  - key:   cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
+    value: '0'
+  - key:   cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
+    value: '0'
+  - key:   cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value: '1'
+  - key:   modernize-loop-convert.MaxCopySize
+    value: '16'
+  - key:   modernize-loop-convert.MinConfidence
+    value: reasonable
+  - key:   modernize-loop-convert.NamingStyle
+    value: camelBack
+  - key:   modernize-pass-by-value.IncludeStyle
+    value: llvm
+  - key:   modernize-replace-auto-ptr.IncludeStyle
+    value: llvm
+  - key:   modernize-use-nullptr.NullMacros
+    value: 'NULL'
+  - key:   readability-braces-around-statements.ShortStatementLines
+    value: '2'
+...

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+/.vscode/*
+
 /deps/*
 !/deps/*.wrap
 !/deps/packagefiles/
+
+/build/

--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,9 @@ project(
 		'buildtype=release',
 		'strip=true',
 		'b_debug=if-release',
-		'b_lto=true'
+		'b_lto=true',
+ 		# libusb needs to pass functions to/from C++ land
+		'cpp_eh=s',
 	],
 	version: '0.0.1',
 	meson_version: '>= 0.63',

--- a/src/actions.cxx
+++ b/src/actions.cxx
@@ -73,6 +73,7 @@ namespace bmpflash
 				return spiDevice_t::intFlash;
 			case spiBus_t::external:
 				return spiDevice_t::extFlash;
+			case spiBus_t::none:
 			default:
 				throw std::domain_error{"SPI bus requested is unhandled or unknown"};
 		}

--- a/src/actions.cxx
+++ b/src/actions.cxx
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // SPDX-FileCopyrightText: 2023 1BitSquared <info@1bitsquared.com>
 // SPDX-FileContributor: Written by Rachel Mant <git@dragonmux.network>
-#define SUBSTRATE_ALLOW_STD_FILESYSTEM_PATH
-
 #include <string>
 #include <string_view>
 #include <substrate/span>

--- a/src/bmp.cxx
+++ b/src/bmp.cxx
@@ -149,7 +149,7 @@ bmp_t::bmp_t(const usbDevice_t &usbDevice) : device{usbDevice.open()}
 	}
 	// Having adjusted the line state, try to do a read of the serial state notification which will be sat in the buffer
 	std::array<uint8_t, 10U> serialState{};
-	static_cast<void>(device.readBulk(rxEndpoint, serialState.data(), serialState.size(), 100ms));
+	static_cast<void>(device.readBulk(rxEndpoint, serialState.data(), static_cast<int32_t>(serialState.size()), 100ms));
 }
 
 bmp_t::~bmp_t() noexcept

--- a/src/bmp.cxx
+++ b/src/bmp.cxx
@@ -154,7 +154,7 @@ bmp_t::bmp_t(const usbDevice_t &usbDevice) : device{usbDevice.open()}
 
 bmp_t::~bmp_t() noexcept
 {
-	if (spiBus != spiBus_t::none)
+	if (_spiBus != spiBus_t::none)
 		static_cast<void>(end());
 	if (ctrlInterfaceNumber != UINT8_MAX)
 		// Send a SET_CONTROL_LINE_STATE control request to reset the interface
@@ -175,8 +175,8 @@ void bmp_t::swap(bmp_t &probe) noexcept
 	std::swap(dataInterfaceNumber, probe.dataInterfaceNumber);
 	std::swap(txEndpoint, probe.txEndpoint);
 	std::swap(rxEndpoint, probe.rxEndpoint);
-	std::swap(spiBus, probe.spiBus);
-	std::swap(spiDevice, probe.spiDevice);
+	std::swap(_spiBus, probe._spiBus);
+	std::swap(_spiDevice, probe._spiDevice);
 }
 
 void bmp_t::writePacket(const std::string_view &packet) const

--- a/src/elf/elf.cxx
+++ b/src/elf/elf.cxx
@@ -36,7 +36,7 @@ namespace bmpflash::elf
 		const auto endian{_header.endian()};
 		const auto programHeaderSize{_header.programHeaderSize()};
 
-		size_t offset{_header.phdrOffset()};
+		auto offset{static_cast<size_t>(_header.phdrOffset())};
 		// Once the elfHeader_t has been read and handled, we then loop through pulling out the program headers.
 		for ([[maybe_unused]] const auto index : substrate::indexSequence_t{_header.programHeaderCount()})
 		{
@@ -109,7 +109,7 @@ namespace bmpflash::elf
 			[&](mmap_t &storage)
 			{
 				const auto &data{toSpan(storage)};
-				return data.subspan(header.offset(), header.fileLength());
+				return data.subspan(static_cast<size_t>(header.offset()), static_cast<size_t>(header.fileLength()));
 			},
 			[&](const fragmentStorage_t &) -> span<uint8_t> { return {}; }
 		}, _backingStorage);
@@ -126,7 +126,7 @@ namespace bmpflash::elf
 			[&](const mmap_t &storage)
 			{
 				const auto &data{toSpan(storage)};
-				return data.subspan(header.offset(), header.fileLength());
+				return data.subspan(static_cast<size_t>(header.offset()), static_cast<size_t>(header.fileLength()));
 			},
 			[&](const fragmentStorage_t &) -> span<const uint8_t> { return {}; }
 		}, _backingStorage);
@@ -143,7 +143,7 @@ namespace bmpflash::elf
 			[&](mmap_t &storage)
 			{
 				const auto &data{toSpan(storage)};
-				return data.subspan(header.fileOffset(), header.fileLength());
+				return data.subspan(static_cast<size_t>(header.fileOffset()), static_cast<size_t>(header.fileLength()));
 			},
 			[&](const fragmentStorage_t &) -> span<uint8_t> { return {}; }
 		}, _backingStorage);
@@ -160,7 +160,7 @@ namespace bmpflash::elf
 			[&](const mmap_t &storage)
 			{
 				const auto &data{toSpan(storage)};
-				return data.subspan(header.fileOffset(), header.fileLength());
+				return data.subspan(static_cast<size_t>(header.fileOffset()), static_cast<size_t>(header.fileLength()));
 			},
 			[&](const fragmentStorage_t &) -> span<const uint8_t> { return {}; }
 		}, _backingStorage);

--- a/src/elf/elf.cxx
+++ b/src/elf/elf.cxx
@@ -5,7 +5,7 @@
 #include "elf.hxx"
 
 // Pull in the mmap_t constants on Windows
-#if _WIN32
+#ifdef _WIN32
 using namespace substrate::constants;
 #endif
 

--- a/src/include/bmp.hxx
+++ b/src/include/bmp.hxx
@@ -44,8 +44,8 @@ private:
 	uint8_t dataInterfaceNumber{UINT8_MAX};
 	uint8_t txEndpoint{};
 	uint8_t rxEndpoint{};
-	spiBus_t spiBus{spiBus_t::none};
-	spiDevice_t spiDevice{spiDevice_t::none};
+	spiBus_t _spiBus{spiBus_t::none};
+	spiDevice_t _spiDevice{spiDevice_t::none};
 	constexpr static size_t maxPacketSize{1024U};
 
 	bmp_t() noexcept = default;

--- a/src/include/defs.hxx
+++ b/src/include/defs.hxx
@@ -14,8 +14,8 @@
 #define ATTR_PACKED [[gnu::packed]]
 #elif defined(_MSC_VER)
 #define STRINGIFY(n) #n
-#define BEGIN_PACKED(n) _Pragma("push(pack, " STRINGIFY(n) ")")
-#define END_PACKED() _Pragma("pop(pack)")
+#define BEGIN_PACKED(n) __pragma(pack(push, n))
+#define END_PACKED() __pragma(pack(pop))
 #define ATTR_PACKED
 #endif
 

--- a/src/include/defs.hxx
+++ b/src/include/defs.hxx
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-FileCopyrightText: 2023 1BitSquared <info@1bitsquared.com>
+// SPDX-FileContributor: Written by Rachel Mant <git@dragonmux.network>
+#ifndef DEFS_HXX
+#define DEFS_HXX
+
+#if defined(__has_include) && __has_include(<version>)
+#include <version>
+#endif
+
+#if (defined(__has_cpp_attribute) && __has_cpp_attribute(gnu::packed)) || defined(__GNUC__)
+#define BEGIN_PACKED(n)
+#define END_PACKED()
+#define ATTR_PACKED [[gnu::packed]]
+#elif defined(_MSC_VER)
+#define STRINGIFY(n) #n
+#define BEGIN_PACKED(n) _Pragma("push(pack, " STRINGIFY(n) ")")
+#define END_PACKED() _Pragma("pop(pack)")
+#define ATTR_PACKED
+#endif
+
+#endif /*DEFS_HXX*/

--- a/src/include/flashVendors.hxx
+++ b/src/include/flashVendors.hxx
@@ -10,12 +10,15 @@
 
 using namespace std::literals::string_view_literals;
 
+constexpr inline uint8_t operator ""_u8(const unsigned long long value)
+	{ return static_cast<uint8_t>(value); }
+
 static const std::map<uint8_t, std::string_view> flashVendors
 {
-	{0x1fU, "Adesto"sv},
-	{0x20U, "Numonyx"sv},
-	{0xc8U, "GigaDevice"sv},
-	{0xefU, "Winbond"sv},
+	{0x1f_u8, "Adesto"sv},
+	{0x20_u8, "Numonyx"sv},
+	{0xc8_u8, "GigaDevice"sv},
+	{0xef_u8, "Winbond"sv},
 };
 
 #endif /*FLASH_VENDORS_HXX*/

--- a/src/include/sfdpInternal.hxx
+++ b/src/include/sfdpInternal.hxx
@@ -111,7 +111,7 @@ END_PACKED()
 
 		[[nodiscard]] uint64_t pageSize() const noexcept
 		{
-			const uint8_t pageSizeExponent = programmingTimingRatioAndPageSize >> 4U;
+			const auto pageSizeExponent{static_cast<uint8_t>(programmingTimingRatioAndPageSize >> 4U)};
 			return UINT64_C(1) << pageSizeExponent;
 		}
 	};

--- a/src/include/sfdpInternal.hxx
+++ b/src/include/sfdpInternal.hxx
@@ -71,11 +71,11 @@ namespace bmpflash::sfdp
 			{ return uint32_t((data[3] & 0x7fU) << 24U) | uint32_t(data[2] << 16U) | uint32_t(data[1] << 8U) | data[0]; }
 
 	public:
-		[[nodiscard]] size_t capacity() const noexcept
+		[[nodiscard]] uint64_t capacity() const noexcept
 		{
 			const auto bits
 			{
-				[=]() -> size_t
+				[=]() -> uint64_t
 				{
 					if (isExponential())
 						return UINT64_C(1) << value();
@@ -97,7 +97,7 @@ namespace bmpflash::sfdp
 		uint8_t eraseSizeExponent{};
 		uint8_t opcode{};
 
-		[[nodiscard]] size_t eraseSize() const noexcept
+		[[nodiscard]] uint64_t eraseSize() const noexcept
 			{ return UINT64_C(1) << eraseSizeExponent; }
 	};
 
@@ -106,7 +106,7 @@ namespace bmpflash::sfdp
 		uint8_t programmingTimingRatioAndPageSize{};
 		std::array<uint8_t, 3> eraseTimings;
 
-		[[nodiscard]] size_t pageSize() const noexcept
+		[[nodiscard]] uint64_t pageSize() const noexcept
 		{
 			const uint8_t pageSizeExponent = programmingTimingRatioAndPageSize >> 4U;
 			return UINT64_C(1) << pageSizeExponent;

--- a/src/include/sfdpInternal.hxx
+++ b/src/include/sfdpInternal.hxx
@@ -78,7 +78,7 @@ namespace bmpflash::sfdp
 				[=]() -> size_t
 				{
 					if (isExponential())
-						return 1U << value();
+						return UINT64_C(1) << value();
 					return value() + 1U;
 				}()
 			};
@@ -97,7 +97,8 @@ namespace bmpflash::sfdp
 		uint8_t eraseSizeExponent{};
 		uint8_t opcode{};
 
-		[[nodiscard]] size_t eraseSize() const noexcept { return 1U << eraseSizeExponent; }
+		[[nodiscard]] size_t eraseSize() const noexcept
+			{ return UINT64_C(1) << eraseSizeExponent; }
 	};
 
 	struct programmingAndChipEraseTiming_t
@@ -108,7 +109,7 @@ namespace bmpflash::sfdp
 		[[nodiscard]] size_t pageSize() const noexcept
 		{
 			const uint8_t pageSizeExponent = programmingTimingRatioAndPageSize >> 4U;
-			return 1U << pageSizeExponent;
+			return UINT64_C(1) << pageSizeExponent;
 		}
 	};
 

--- a/src/include/sfdpInternal.hxx
+++ b/src/include/sfdpInternal.hxx
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <cstddef>
 #include <array>
+#include "defs.hxx"
 
 namespace bmpflash::sfdp
 {
@@ -86,13 +87,14 @@ namespace bmpflash::sfdp
 		}
 	};
 
-	struct [[gnu::packed]] timingsAndOpcode_t
+BEGIN_PACKED(1)
+	struct ATTR_PACKED timingsAndOpcode_t
 	{
 		uint8_t timings{};
 		uint8_t opcode{};
 	};
 
-	struct [[gnu::packed]] eraseParameters_t
+	struct ATTR_PACKED eraseParameters_t
 	{
 		uint8_t eraseSizeExponent{};
 		uint8_t opcode{};
@@ -100,6 +102,7 @@ namespace bmpflash::sfdp
 		[[nodiscard]] uint64_t eraseSize() const noexcept
 			{ return UINT64_C(1) << eraseSizeExponent; }
 	};
+END_PACKED()
 
 	struct programmingAndChipEraseTiming_t
 	{

--- a/src/include/spiFlash.hxx
+++ b/src/include/spiFlash.hxx
@@ -95,9 +95,9 @@ namespace bmpflash::spiFlash
 	public:
 		constexpr spiFlash_t() noexcept = default;
 		constexpr spiFlash_t(const size_t capacity) noexcept : capacity_{capacity} { }
-		constexpr spiFlash_t(const size_t pageSize, const size_t sectorSize, const uint8_t sectorEraseOpcode,
-			const size_t capacity) noexcept : pageSize_{static_cast<uint32_t>(pageSize)},
-				sectorSize_{static_cast<uint32_t>(sectorSize)}, capacity_{capacity},
+		constexpr spiFlash_t(const uint64_t pageSize, const uint64_t sectorSize, const uint8_t sectorEraseOpcode,
+			const uint64_t capacity) noexcept : pageSize_{static_cast<uint32_t>(pageSize)},
+				sectorSize_{static_cast<uint32_t>(sectorSize)}, capacity_{static_cast<size_t>(capacity)},
 				sectorEraseOpcode_{sectorEraseOpcode} { }
 
 		[[nodiscard]] constexpr auto valid() const noexcept { return capacity_ != 0U; }

--- a/src/include/usbConfiguration.hxx
+++ b/src/include/usbConfiguration.hxx
@@ -20,7 +20,7 @@ public:
 	// NOLINTNEXTLINE(modernize-use-equals-default)
 	~usbConfiguration_t() noexcept { libusb_free_config_descriptor(config); }
 
-	[[nodiscard]] bool valid() const noexcept { return config; }
+	[[nodiscard]] auto valid() const noexcept { return config != nullptr; }
 	[[nodiscard]] uint8_t interfaces() const noexcept { return config->bNumInterfaces; }
 
 	// NOLINTNEXTLINE(readability-convert-member-functions-to-static)

--- a/src/include/usbContext.hxx
+++ b/src/include/usbContext.hxx
@@ -58,7 +58,7 @@ public:
 		return *this;
 	}
 
-	[[nodiscard]] bool valid() const noexcept { return context; }
+	[[nodiscard]] auto valid() const noexcept { return context != nullptr; }
 
 	// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 	[[nodiscard]] usbDeviceList_t deviceList() const noexcept

--- a/src/include/usbDevice.hxx
+++ b/src/include/usbDevice.hxx
@@ -178,9 +178,21 @@ public:
 	usbDeviceHandle_t() noexcept = default;
 	usbDeviceHandle_t(libusb_device_handle *const device_) noexcept : device{device_}
 		{ autoDetachKernelDriver(true); }
+	usbDeviceHandle_t(const usbDeviceHandle_t &) noexcept = delete;
+	usbDeviceHandle_t(usbDeviceHandle_t &&handle) noexcept : usbDeviceHandle_t{} { swap(handle); }
 	// NOLINTNEXTLINE(modernize-use-equals-default)
 	~usbDeviceHandle_t() noexcept { libusb_close(device); }
+	usbDeviceHandle_t &operator =(const usbDeviceHandle_t &) noexcept = delete;
 	[[nodiscard]] auto valid() const noexcept { return device != nullptr; }
+
+	usbDeviceHandle_t &operator =(usbDeviceHandle_t &&handle) noexcept
+	{
+		swap(handle);
+		return *this;
+	}
+
+	void swap(usbDeviceHandle_t &handle) noexcept
+		{ std::swap(device, handle.device); }
 
 	// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 	void autoDetachKernelDriver(bool autoDetach) const noexcept

--- a/src/include/usbDevice.hxx
+++ b/src/include/usbDevice.hxx
@@ -60,7 +60,14 @@ public:
 	constexpr requestType_t(const recipient_t recipient, const request_t type) noexcept :
 		requestType_t{recipient, type, endpointDir_t::controllerOut} { }
 	constexpr requestType_t(const recipient_t recipient, const request_t type, const endpointDir_t direction) noexcept :
-		value(static_cast<uint8_t>(recipient) | static_cast<uint8_t>(type) | static_cast<uint8_t>(direction)) { }
+		value
+		{
+			static_cast<uint8_t>(
+				static_cast<uint8_t>(recipient) |
+				static_cast<uint8_t>(type) |
+				static_cast<uint8_t>(direction)
+			)
+		} { }
 
 	void recipient(const recipient_t recipient) noexcept
 	{

--- a/src/include/usbDevice.hxx
+++ b/src/include/usbDevice.hxx
@@ -211,7 +211,8 @@ public:
 		std::array<uint8_t, 512> stringData{};
 		const auto result
 		{
-			libusb_get_string_descriptor(device, stringIndex, languageID, stringData.data(), stringData.size())
+			libusb_get_string_descriptor(device, stringIndex, languageID, stringData.data(),
+				static_cast<int>(stringData.size()))
 		};
 		// Check for USB errors and report them
 		if (result < 0)

--- a/src/include/usbDevice.hxx
+++ b/src/include/usbDevice.hxx
@@ -173,7 +173,7 @@ public:
 		{ autoDetachKernelDriver(true); }
 	// NOLINTNEXTLINE(modernize-use-equals-default)
 	~usbDeviceHandle_t() noexcept { libusb_close(device); }
-	[[nodiscard]] bool valid() const noexcept { return device; }
+	[[nodiscard]] auto valid() const noexcept { return device != nullptr; }
 
 	// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 	void autoDetachKernelDriver(bool autoDetach) const noexcept

--- a/src/include/usbEndpoint.hxx
+++ b/src/include/usbEndpoint.hxx
@@ -17,7 +17,7 @@ public:
 	usbEndpoint_t() noexcept = default;
 	usbEndpoint_t(const libusb_endpoint_descriptor *const endpoint_) noexcept : endpoint{endpoint_} { }
 
-	[[nodiscard]] bool valid() const noexcept { return endpoint; }
+	[[nodiscard]] auto valid() const noexcept { return endpoint != nullptr; }
 	[[nodiscard]] auto direction() const noexcept
 		{ return static_cast<endpointDir_t>(endpoint->bEndpointAddress & ~endpointDirMask); }
 	[[nodiscard]] uint8_t address() const noexcept { return endpoint->bEndpointAddress & endpointDirMask; }

--- a/src/include/usbEndpoint.hxx
+++ b/src/include/usbEndpoint.hxx
@@ -20,7 +20,8 @@ public:
 	[[nodiscard]] auto valid() const noexcept { return endpoint != nullptr; }
 	[[nodiscard]] auto direction() const noexcept
 		{ return static_cast<endpointDir_t>(endpoint->bEndpointAddress & ~endpointDirMask); }
-	[[nodiscard]] uint8_t address() const noexcept { return endpoint->bEndpointAddress & endpointDirMask; }
+	[[nodiscard]] auto address() const noexcept
+		{ return static_cast<uint8_t>(endpoint->bEndpointAddress & endpointDirMask); }
 };
 
 #endif /*USB_ENDPOINT_HXX*/

--- a/src/include/usbInterface.hxx
+++ b/src/include/usbInterface.hxx
@@ -20,7 +20,7 @@ public:
 	usbInterfaceAltMode_t() noexcept = default;
 	usbInterfaceAltMode_t(const libusb_interface_descriptor *const iface) noexcept : interface{iface} { }
 
-	[[nodiscard]] bool valid() const noexcept { return interface; }
+	[[nodiscard]] auto valid() const noexcept { return interface != nullptr; }
 	[[nodiscard]] uint8_t endpoints() const noexcept { return interface->bNumEndpoints; }
 	[[nodiscard]] uint8_t interfaceNumber() const noexcept { return interface->bInterfaceNumber; }
 	[[nodiscard]] auto interfaceClass() const noexcept
@@ -54,7 +54,7 @@ public:
 	usbInterface_t() noexcept = default;
 	usbInterface_t(const libusb_interface *const iface) noexcept : interface{iface} { }
 
-	[[nodiscard]] bool valid() const noexcept { return interface; }
+	[[nodiscard]] auto valid() const noexcept { return interface != nullptr; }
 	[[nodiscard]] auto altModes() const noexcept { return static_cast<size_t>(interface->num_altsetting); }
 
 	[[nodiscard]] usbInterfaceAltMode_t altMode(const size_t index) const noexcept

--- a/src/include/usbTypes.hxx
+++ b/src/include/usbTypes.hxx
@@ -5,6 +5,7 @@
 #define USB_TYPES_HXX
 
 #include <cstdint>
+#include "defs.hxx"
 
 enum class endpointDir_t : uint8_t
 {
@@ -105,13 +106,15 @@ namespace usb::descriptors
 			descriptorSubtype_t subtype;
 		};
 
-		struct [[gnu::packed]] headerDescriptor_t final
+	BEGIN_PACKED(1)
+		struct ATTR_PACKED headerDescriptor_t final
 		{
 			uint8_t length;
 			descriptorType_t type;
 			descriptorSubtype_t subtype;
 			uint16_t cdcVersion;
 		};
+	END_PACKED()
 
 		struct callManagementDescriptor_t final
 		{

--- a/src/include/usbTypes.hxx
+++ b/src/include/usbTypes.hxx
@@ -14,8 +14,8 @@ enum class endpointDir_t : uint8_t
 };
 
 constexpr static const uint8_t endpointDirMask{0x7fU};
-constexpr inline uint8_t endpointAddress(const endpointDir_t dir, const uint8_t number) noexcept
-	{ return uint8_t(dir) | (number & endpointDirMask); }
+constexpr inline auto endpointAddress(const endpointDir_t dir, const uint8_t number) noexcept
+	{ return static_cast<uint8_t>(static_cast<uint8_t>(dir) | static_cast<uint8_t>(number & endpointDirMask)); }
 
 // This code is borrowed from dragonUSB
 namespace usb::descriptors
@@ -179,8 +179,8 @@ namespace usb::types::cdc
 		rtsActivate = 2U,
 	};
 
-	constexpr inline uint16_t operator |(const controlLines_t lhs, const controlLines_t rhs) noexcept
-		{ return uint16_t(lhs) | uint16_t(rhs); }
+	constexpr inline auto operator |(const controlLines_t lhs, const controlLines_t rhs) noexcept
+		{ return static_cast<uint16_t>(static_cast<uint16_t>(lhs) | static_cast<uint16_t>(rhs)); }
 } // namespace usb::types::cdc
 
 #endif /*USB_TYPES_HXX*/

--- a/src/meson.build
+++ b/src/meson.build
@@ -68,16 +68,16 @@ extendedWarnings = [
 	# -Wno-inline
 	'-wd4710', # 'identifier': function not inlined
 	'-wd4711', # function 'identifier' selected for automatic inline expansion
+	'-wd4514', # 'identifier': unreferenced inline function has been removed
 
 	# -Wunused
-	'-w34514', # 'identifier': unreferenced inline function has been removed
 	'-w35264', # 'identifier': 'const' variable is not used
 
 	# -Wundef
 	'-w34668', # '___cplusplus' is not defined as a preprocessor macro, replacing with '0' for '#if/#elif''
 
 	# -Wpacked -- disabling because MSVC uses pragmas for packing
-	'-w34820', # 'identifier': 'X' bytes padding added after data member 'identifier'
+	'-wd4820', # 'identifier': 'X' bytes padding added after data member 'identifier'
 
 	# -Wignored-qualifiers
 	'-w35266', # 'const' qualifier on return type has no effect
@@ -89,11 +89,11 @@ extendedWarnings = [
 	'-w34061', # enumerator 'identifier' in switch of enum 'identifier' is not explicitly handled by a case label
 
 	# -Wdefaulted-function-deleted
-	'-w34625', # 'identifier': copy constructor was implicitly defined as deleted
-	'-w34626', # 'identifier': assignment operator was implicitly defined as deleted
-	'-w34623', # 'identifier': default constructor was implicitly defined as deleted
-	'-w35026', # 'identifier': move constructor was implicitly defined as deleted
-	'-w35027', # 'identifier': move assignment operator was implicitly defined as deleted
+	'-wd4625', # 'identifier': copy constructor was implicitly defined as deleted
+	'-wd4626', # 'identifier': assignment operator was implicitly defined as deleted
+	'-wd4623', # 'identifier': default constructor was implicitly defined as deleted
+	'-wd5026', # 'identifier': move constructor was implicitly defined as deleted
+	'-wd5027', # 'identifier': move assignment operator was implicitly defined as deleted
 
 	# -Wdeprecated(-copy)
 	'-w35267', # definition of implicit copy constructor for 'identifier' is deprecated because it has a user-provided destructor'

--- a/src/meson.build
+++ b/src/meson.build
@@ -39,7 +39,7 @@ extendedWarnings = [
 #	'-Wpacked',
 #	'-Wpadded',
 	'-Wredundant-decls',
-	'-Winline',
+#	'-Winline',
 	'-Wvla',
 	'-Wstack-protector',
 	'-Wunsuffixed-float-constant',

--- a/src/meson.build
+++ b/src/meson.build
@@ -44,6 +44,62 @@ extendedWarnings = [
 	'-Wstack-protector',
 	'-Wunsuffixed-float-constant',
 	'-Wimplicit-fallthrough',
+	'-Wundef',
+	'-Wignored-qualifiers',
+	'-Wshadow',
+	'-Wswitch-enum',
+	'-Wdefaulted-function-deleted',
+	'-Wdeprecated-copy',
+
+	# MSVC unique warnings that are useful
+	'-w35030', # attribute 'gnu::packed' is not recognized
+	'-w35039', # 'identifier': pointer or reference to potentially throwing function passed to 'extern "C"' function under -EHc. Undefined behavior may occur if this function throws an exception.
+	'-w35045', # Compiler will insert Spectre mitigation for memory load if /Qspectre switch specified
+
+	# -Wmaybe-uninitialized -- UB
+	'-w34355', # 'this': used in base member initializer list
+
+	# -Wconversion
+	'-w34242', # 'initializing': conversion from '_Ty' to '_Ty1', possible loss of data
+	'-w34244', # 'return': conversion from '_Ty' to '_Ty1', possible loss of data
+	'-w34365', # 'identifier': conversion from 'identifier' to 'identifier', signed/unsigned mismatch
+	'-w34800', # Implicit conversion from 'identifier' to bool. Possible information loss
+
+	# -Wno-inline
+	'-wd4710', # 'identifier': function not inlined
+	'-wd4711', # function 'identifier' selected for automatic inline expansion
+
+	# -Wunused
+	'-w34514', # 'identifier': unreferenced inline function has been removed
+	'-w35264', # 'identifier': 'const' variable is not used
+
+	# -Wundef
+	'-w34668', # '___cplusplus' is not defined as a preprocessor macro, replacing with '0' for '#if/#elif''
+
+	# -Wpacked -- disabling because MSVC uses pragmas for packing
+	'-w34820', # 'identifier': 'X' bytes padding added after data member 'identifier'
+
+	# -Wignored-qualifiers
+	'-w35266', # 'const' qualifier on return type has no effect
+
+	# -Wshadow
+	'-w34458', # declaration of 'device' hides class member
+
+	# -Wswitch-enum
+	'-w34061', # enumerator 'identifier' in switch of enum 'identifier' is not explicitly handled by a case label
+
+	# -Wdefaulted-function-deleted
+	'-w34625', # 'identifier': copy constructor was implicitly defined as deleted
+	'-w34626', # 'identifier': assignment operator was implicitly defined as deleted
+	'-w34623', # 'identifier': default constructor was implicitly defined as deleted
+	'-w35026', # 'identifier': move constructor was implicitly defined as deleted
+	'-w35027', # 'identifier': move assignment operator was implicitly defined as deleted
+
+	# -Wdeprecated(-copy)
+	'-w35267', # definition of implicit copy constructor for 'identifier' is deprecated because it has a user-provided destructor'
+
+	# Undocumented
+	'-wd4582', # 'identifier': constructor is not implicitly called
 ]
 
 add_project_arguments(

--- a/src/provisionELF.cxx
+++ b/src/provisionELF.cxx
@@ -112,7 +112,7 @@ namespace bmpflash::elf
 	{
 		// If there are no sections stored yet, the offset of the first is at the start of the second erase block
 		if (flashHeader.sections.empty())
-			return 4_KiB;
+			return static_cast<uint32_t>(4_KiB);
 		// Otherwise, grab the last and compute the next offset
 		const auto &last{flashHeader.sections.back()};
 		const auto offset{last.offset + last.length};

--- a/src/provisionELF.cxx
+++ b/src/provisionELF.cxx
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // SPDX-FileCopyrightText: 2023 1BitSquared <info@1bitsquared.com>
 // SPDX-FileContributor: Written by Rachel Mant <git@dragonmux.network>
-#define SUBSTRATE_ALLOW_STD_FILESYSTEM_PATH
-
 #include <cstddef>
 #include <string_view>
 #include <map>

--- a/src/provisionELF.cxx
+++ b/src/provisionELF.cxx
@@ -233,7 +233,7 @@ namespace bmpflash::elf
 
 	bool flashHeader_t::toPage(span<uint8_t> pageBuffer) const noexcept try
 	{
-		std::fill(pageBuffer.begin(), pageBuffer.end(), 0xffU);
+		std::fill(pageBuffer.begin(), pageBuffer.end(), static_cast<uint8_t>(0xffU));
 		copyInto(pageBuffer.subspan(0, 4), flashMagic);
 		writeLE(static_cast<uint32_t>(sections.size()), pageBuffer.subspan(8, 4));
 

--- a/src/remoteSPI.cxx
+++ b/src/remoteSPI.cxx
@@ -102,35 +102,35 @@ uint64_t bmp_t::readProtocolVersion() const
 	return version.fromHex();
 }
 
-bool bmp_t::begin(const spiBus_t bus, const spiDevice_t device) noexcept
+bool bmp_t::begin(const spiBus_t spiBus, const spiDevice_t spiDevice) noexcept
 {
-	const auto request{fmt::format(remoteSPIBegin, uint8_t(bus))};
+	const auto request{fmt::format(remoteSPIBegin, uint8_t(spiBus))};
 	writePacket(request);
 	const auto response{readPacket()};
 	if (response[0] == remoteResponseOK)
 	{
-		spiBus = bus;
-		spiDevice = device;
+		_spiBus = spiBus;
+		_spiDevice = spiDevice;
 	}
 	return response[0] == remoteResponseOK;
 }
 
 bool bmp_t::end() noexcept
 {
-	const auto request{fmt::format(remoteSPIEnd, uint8_t(spiBus))};
+	const auto request{fmt::format(remoteSPIEnd, uint8_t(_spiBus))};
 	writePacket(request);
 	const auto response{readPacket()};
 	if (response[0] == remoteResponseOK)
 	{
-		spiBus = spiBus_t::none;
-		spiDevice = spiDevice_t::none;
+		_spiBus = spiBus_t::none;
+		_spiDevice = spiDevice_t::none;
 	}
 	return response[0] == remoteResponseOK;
 }
 
 spiFlashID_t bmp_t::identifyFlash() const
 {
-	const auto request{fmt::format(remoteSPIChipID, uint8_t(spiBus), uint8_t(spiDevice))};
+	const auto request{fmt::format(remoteSPIChipID, uint8_t(_spiBus), uint8_t(_spiDevice))};
 	writePacket(request);
 	const auto response{readPacket()};
 	if (response[0] != remoteResponseOK)
@@ -151,7 +151,7 @@ bool bmp_t::read(const spiFlashCommand_t command, const uint32_t address, void *
 	if (dataLength > UINT16_MAX)
 		return false;
 
-	const auto request{fmt::format(remoteSPIRead, uint8_t(spiBus), uint8_t(spiDevice), uint16_t(command),
+	const auto request{fmt::format(remoteSPIRead, uint8_t(_spiBus), uint8_t(_spiDevice), uint16_t(command),
 		address & 0x00ffffffU, dataLength)};
 	writePacket(request);
 	const auto response{readPacket()};
@@ -179,7 +179,7 @@ bool bmp_t::write(const spiFlashCommand_t command, const uint32_t address, const
 	{
 		static_cast<size_t>
 		(
-			fmt::format_to_n(request.begin(), request.size(), remoteSPIWrite, uint8_t(spiBus), uint8_t(spiDevice),
+			fmt::format_to_n(request.begin(), request.size(), remoteSPIWrite, uint8_t(_spiBus), uint8_t(_spiDevice),
 			uint16_t(command), address & 0x00ffffffU, dataLength).out - request.begin()
 		)
 	};
@@ -198,7 +198,7 @@ bool bmp_t::write(const spiFlashCommand_t command, const uint32_t address, const
 
 bool bmp_t::runCommand(const spiFlashCommand_t command, const uint32_t address) const
 {
-	const auto request{fmt::format(remoteSPICommand, uint8_t(spiBus), uint8_t(spiDevice), uint16_t(command),
+	const auto request{fmt::format(remoteSPICommand, uint8_t(_spiBus), uint8_t(_spiDevice), uint16_t(command),
 		address & 0x00ffffffU)};
 	writePacket(request);
 	const auto response{readPacket()};

--- a/src/remoteSPI.cxx
+++ b/src/remoteSPI.cxx
@@ -3,7 +3,19 @@
 // SPDX-FileContributor: Written by Rachel Mant <git@dragonmux.network>
 #include <string>
 #include <string_view>
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4061 4365)
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wswitch-enum"
+#endif
 #include <fmt/format.h>
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 #include <substrate/conversions>
 #include <substrate/span>
 #include <substrate/index_sequence>
@@ -180,7 +192,7 @@ bool bmp_t::write(const spiFlashCommand_t command, const uint32_t address, const
 		static_cast<size_t>
 		(
 			fmt::format_to_n(request.begin(), request.size(), remoteSPIWrite, uint8_t(_spiBus), uint8_t(_spiDevice),
-			uint16_t(command), address & 0x00ffffffU, dataLength).out - request.begin()
+				uint16_t(command), address & 0x00ffffffU, dataLength).out - request.begin()
 		)
 	};
 	offset += toHex(data, dataLength, substrate::span{request}.subspan(offset, maxPacketSize - offset));

--- a/src/sfdp.cxx
+++ b/src/sfdp.cxx
@@ -61,7 +61,8 @@ namespace bmpflash::sfdp
 			return false;
 
 		console.info("Basic parameter table:");
-		const auto [capacityValue, capacityUnits] = humanReadableSize(parameterTable.flashMemoryDensity.capacity());
+		const auto [capacityValue, capacityUnits] =
+			humanReadableSize(static_cast<size_t>(parameterTable.flashMemoryDensity.capacity()));
 		console.info("-> capacity "sv, capacityValue, capacityUnits);
 		console.info("-> program page size: "sv, parameterTable.programmingAndChipEraseTiming.pageSize());
 		console.info("-> sector erase opcode: "sv, asHex_t<2, '0'>(parameterTable.sectorEraseOpcode));
@@ -71,7 +72,7 @@ namespace bmpflash::sfdp
 			console.info("\t-> "sv, idx + 1U, ": "sv, nullptr);
 			if (eraseType.eraseSizeExponent != 0U)
 			{
-				const auto [sizeValue, sizeUnits] = humanReadableSize(eraseType.eraseSize());
+				const auto [sizeValue, sizeUnits] = humanReadableSize(static_cast<size_t>(eraseType.eraseSize()));
 				console.writeln("opcode "sv, asHex_t<2, '0'>(eraseType.opcode), ", erase size: "sv,
 					sizeValue, sizeUnits);
 			}
@@ -135,7 +136,7 @@ namespace bmpflash::sfdp
 
 		const auto [sectorSize, sectorEraseOpcode]
 		{
-			[&]() -> std::tuple<size_t, uint8_t>
+			[&]() -> std::tuple<uint64_t, uint8_t>
 			{
 				for (const auto &eraseType : parameterTable.eraseTypes)
 				{


### PR DESCRIPTION
This PR aims to clean up the Windows builds of the tool and fix as many of the warnings that were being produced as is practical. This also includes the addition of warning enables for MSVC mirroring the set we enable for Clang and GCC, with thanks to Amy.

This fixes a few bugs in the process, such as packed structures being misgenerated if using MSVC, and exceptions via C code (eg, libusb) traversing wrongly due to some tricky issues with how windows exceptions work.

There will be a follow-up PR after this to enable at least Linux and MSYS2 based CI. MSVC CI requires release 19.37 of MSVC 2022 which is one minor newer than is available right now on GHA (19.36, when you get the right image, 19.35 otherwise). The versions available on GHA sport bugs that break compilation unfixably. The CI PR will also aim to guard against this broken behaviour on user systems.