### PR TITLE
Fix: SFDP basic parameter table handling

### DIFF
--- a/src/include/flashVendors.hxx
+++ b/src/include/flashVendors.hxx
@@ -17,6 +17,7 @@ static const std::map<uint8_t, std::string_view> flashVendors
 {
 	{0x1f_u8, "Adesto"sv},
 	{0x20_u8, "Numonyx"sv},
+	{0xc2_u8, "Macronix"sv},
 	{0xc8_u8, "GigaDevice"sv},
 	{0xef_u8, "Winbond"sv},
 };

--- a/src/include/sfdpInternal.hxx
+++ b/src/include/sfdpInternal.hxx
@@ -40,8 +40,8 @@ namespace bmpflash::sfdp
 	struct sfdpHeader_t
 	{
 		std::array<char, 4> magic{};
-		uint8_t versionMajor{};
 		uint8_t versionMinor{};
+		uint8_t versionMajor{};
 		uint8_t rawParameterHeadersCount{};
 		accessProtocol_t accessProtocol{accessProtocol_t::legacyJESD216B};
 
@@ -51,8 +51,8 @@ namespace bmpflash::sfdp
 	struct parameterTableHeader_t
 	{
 		uint8_t jedecParameterIDLow{};
-		uint8_t versionMajor{};
 		uint8_t versionMinor{};
+		uint8_t versionMajor{};
 		uint8_t tableLengthInU32s{};
 		uint24_t tableAddress{};
 		uint8_t jedecParameterIDHigh{};


### PR DESCRIPTION
Mirroring the fix in BMD PR blackmagic-debug/blackmagic#1599 this PR addresses an oversight and failing in the SFDP implementation which made the tool mis-handle devices that follow old versions of the specification.

The practical upshot of the bug is that we'd use invalid (0-init) data past the end of the extracted basic parameters table to determine the page program size of the device, leading to problems in all downstream uses of this data.