### PR TITLE
Fix: macOS Homebrew CI

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -94,7 +94,6 @@ jobs:
     # rdar://FB11369327
     name: '${{ matrix.os }} (homebrew, ${{ matrix.compiler }})'
     runs-on: ${{ matrix.os }}
-    if: false
     defaults:
       run:
         shell: bash
@@ -144,7 +143,8 @@ jobs:
           meson --version
           ninja --version
       - name: Configure
-        run: meson setup build --prefix=$HOME/.local $BUILD_OPTS
+        # GCC on macOS cannot do LTO for now due to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111635
+        run: meson setup build --prefix=$HOME/.local -Db_lto=false $BUILD_OPTS
       - name: Build
         run: meson compile -C build
       - name: Test
@@ -156,7 +156,7 @@ jobs:
         # Codecov no longer parses gcov files automatically
         run: |
           rm -rf build
-          meson setup build --prefix=$HOME/.local -Db_coverage=true --buildtype=debug
+          meson setup build --prefix=$HOME/.local -Db_lto=false -Db_coverage=true --buildtype=debug $BUILD_OPTS
           meson compile -C build
           meson test -C build
           ninja -C build coverage-xml

--- a/src/meson.build
+++ b/src/meson.build
@@ -3,6 +3,13 @@
 # SPDX-FileContributor: Written by Rachel Mant <git@dragonmux.network>
 cxx = meson.get_compiler('cpp')
 
+if get_option('b_lto') and host_machine.system() == 'darwin' and cxx.get_id() == 'gcc'
+	error(
+		'GCC on macOS does not correctly implement support for LTO, please pass `-Db_lto=false` to Meson\n',
+		'-> See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111635 for details'
+	)
+endif
+
 if cxx.get_id() == 'msvc' and cxx.version().version_compare('<19.37')
 	error('Your compiler is broken, please upgrade to at least MSVC 2022 release 17.7 to build bmpflash with MSVC.')
 endif


### PR DESCRIPTION
This PR aims, with many thanks to @amyspark for her help figuring this out, to enable the Homebrew part of the CI matrix and guard against the GCC bug we were inadvertently triggering.

With this, all CI jobs for macOS are enabled and working.