### PR TITLE
Feature: Windows support

### DIFF
--- a/src/bmp.cxx
+++ b/src/bmp.cxx
@@ -1,211 +1,21 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // SPDX-FileCopyrightText: 2023 1BitSquared <info@1bitsquared.com>
 // SPDX-FileContributor: Written by Rachel Mant <git@dragonmux.network>
-#include <cstring>
-#include <substrate/console>
-#include <substrate/index_sequence>
-#include <substrate/span>
 #include "bmp.hxx"
 
-using substrate::console;
-using usb::descriptors::usbClass_t;
-using cdcCommsSubclass_t = usb::descriptors::subclasses::cdcComms_t;
-using cdcCommsProtocol_t = usb::descriptors::protocols::cdcComms_t;
-using usb::descriptors::cdc::functionalDescriptor_t;
-using usb::descriptors::cdc::callManagementDescriptor_t;
-using cdcRequest_t = usb::types::cdc::request_t;
-using usb::types::cdc::controlLines_t;
-
-template<typename descriptor_t> auto descriptorFromSpan(const substrate::span<const uint8_t> &data) noexcept
-{
-	descriptor_t result{};
-	// Check there's at least enough data to fill the structure
-	if (data.size() < sizeof(result))
-		return result;
-	// Copy the necessary data and return it
-	std::memcpy(&result, data.data(), sizeof(result));
-	return result;
-}
-
-uint8_t locateDataInterface(const substrate::span<const uint8_t> &descriptorData) noexcept
-{
-	using usb::descriptors::cdc::descriptorType_t;
-	using usb::descriptors::cdc::descriptorSubtype_t;
-	size_t offset{};
-	// Iterate through the descriptor data
-	for (; offset < descriptorData.size(); )
-	{
-		// Safely unpack the next descriptor
-		auto descriptor{descriptorFromSpan<functionalDescriptor_t>(descriptorData.subspan(offset))};
-		// Check if it's a call management descriptor
-		if (descriptor.length == sizeof(callManagementDescriptor_t) &&
-			descriptor.type == descriptorType_t::interface &&
-			descriptor.subtype == descriptorSubtype_t::callManagement)
-		{
-			console.debug("Found CDC Call Management descriptor in extra data at +"sv, offset);
-			// Try unpacking the descriptor
-			auto callManagement{descriptorFromSpan<callManagementDescriptor_t>(descriptorData.subspan(offset))};
-			// If the length is 0, unpacking failed so bail out
-			if (!callManagement.length)
-				break;
-			console.debug("Found GDB server data interface number: "sv, callManagement.dataInterface);
-			// Otherwise, we've got our data interface!
-			return callManagement.dataInterface;
-		}
-		// Try to increment the offset by the length and check the length's not 0
-		// (if it is, unpacking failed so we should bail out)
-		offset += descriptor.length;
-		if (!descriptor.length)
-			break;
-	}
-	return UINT8_MAX;
-}
-
-std::pair<uint8_t, uint8_t> extractGDBInterface(const usbDeviceHandle_t &device, const usbConfiguration_t &config)
-{
-	// Iterate through the interfaces the configuration defines
-	for (const auto idx : substrate::indexSequence_t{config.interfaces()})
-	{
-		// Get each interface and inspect the first alt-mode
-		const auto interface{config.interface(idx)};
-		if (!interface.valid())
-			break;
-		const auto firstAltMode{interface.altMode(0)};
-		if (!firstAltMode.valid())
-			break;
-
-		// Look for interfaces implementing CDC ACM
-		if (firstAltMode.interfaceClass() != usbClass_t::cdcComms ||
-			firstAltMode.interfaceSubClass<cdcCommsSubclass_t>() != cdcCommsSubclass_t::abstractControl ||
-			firstAltMode.interfaceProtocol<cdcCommsProtocol_t>() != cdcCommsProtocol_t::none)
-			continue;
-
-		// Now grab the interface description string and check it matches the GDB server interface string
-		const auto ifaceName{device.readStringDescriptor(firstAltMode.interfaceIndex())};
-		console.debug("Found CDC ACM interface: "sv, ifaceName);
-		if (ifaceName != "Black Magic GDB Server"sv)
-			continue;
-		console.debug("Found GDB server interface at index "sv, idx, " ("sv, firstAltMode.interfaceNumber(), ')');
-
-		// Found it! Now parse the CDC functional descriptors that follow to find the data interface number
-		return {firstAltMode.interfaceNumber(), locateDataInterface(firstAltMode.extraDescriptors())};
-	}
-	return {UINT8_MAX, UINT8_MAX};
-}
-
-bmp_t::bmp_t(const usbDevice_t &usbDevice) : device{usbDevice.open()}
-{
-	// To figure out the endpoints for the GDB serial port, first grab the active configuration
-	const auto config{usbDevice.activeConfiguration()};
-	if (!config.valid())
-		return;
-	// Then hunt through the descriptors looking for the data interface number
-	std::tie(ctrlInterfaceNumber, dataInterfaceNumber) = extractGDBInterface(device, config);
-	// Check for errors finding the data interface
-	if (dataInterfaceNumber == UINT8_MAX)
-	{
-		console.error("Failed to find GDB server data interface"sv);
-		return;
-	}
-
-	// Re-iterate the interface list to find the data interface
-	for (const auto idx : substrate::indexSequence_t{config.interfaces()})
-	{
-		// Get each interface and inspect the first alt-mode
-		const auto interface{config.interface(idx)};
-		// Check that the interface is valid, skip if not
-		if (!interface.valid())
-			continue;
-		const auto firstAltMode{interface.altMode(0)};
-		// Check that the mode is valid, skip if not
-		if (!firstAltMode.valid())
-			continue;
-
-		// Check if the interface matches the data interface index
-		if (firstAltMode.interfaceNumber() != dataInterfaceNumber)
-			continue;
-
-		// We've got a match, so now check how many endpoints are reported
-		if (firstAltMode.endpoints() != 2U)
-		{
-			console.error("Probe descriptors are invalid"sv);
-			return;
-		}
-		// And iterate through them to extract the addresses
-		for (const auto epIndex : substrate::indexSequence_t{2U})
-		{
-			const auto endpoint{firstAltMode.endpoint(epIndex)};
-			if (endpoint.direction() == endpointDir_t::controllerOut)
-				txEndpoint = endpoint.address();
-			else
-				rxEndpoint = endpoint.address();
-		}
-		break;
-	}
-	// Validate the endpoint IDs and claim the interface, then, having claimed the interface
-	// ask it to become active by sending a SET_CONTROL_LINE_STATE control request via
-	// the associated CDC control interface}
-	if (!txEndpoint || !rxEndpoint || !device.claimInterface(ctrlInterfaceNumber) || !device.claimInterface(dataInterfaceNumber) ||
-		!device.writeControl({recipient_t::interface, request_t::typeClass}, uint8_t(cdcRequest_t::setControlLineState),
-			controlLines_t::dtrPresent | controlLines_t::rtsActivate, ctrlInterfaceNumber, nullptr))
-	{
-		// If either of them are bad, we couldn't claim the interface, or we couldn't send the control request, invalidate both.
-		txEndpoint = 0U;
-		rxEndpoint = 0U;
-	}
-	// Having adjusted the line state, try to do a read of the serial state notification which will be sat in the buffer
-	std::array<uint8_t, 10U> serialState{};
-	static_cast<void>(device.readBulk(rxEndpoint, serialState.data(), static_cast<int32_t>(serialState.size()), 100ms));
-}
+bmp_t::bmp_t(const usbDevice_t &usbDevice) : device{usbDevice} { }
 
 bmp_t::~bmp_t() noexcept
 {
 	if (_spiBus != spiBus_t::none)
 		static_cast<void>(end());
-	if (ctrlInterfaceNumber != UINT8_MAX)
-		// Send a SET_CONTROL_LINE_STATE control request to reset the interface
-		static_cast<void>(device.writeControl({recipient_t::interface, request_t::typeClass},
-			uint8_t(cdcRequest_t::setControlLineState), 0U, ctrlInterfaceNumber, nullptr));
-	if (dataInterfaceNumber != UINT8_MAX)
-		// Release the data interface
-		static_cast<void>(device.releaseInterface(dataInterfaceNumber));
-	if (ctrlInterfaceNumber != UINT8_MAX)
-		// Release the data interface
-		static_cast<void>(device.releaseInterface(ctrlInterfaceNumber));
 }
 
 void bmp_t::swap(bmp_t &probe) noexcept
 {
-	std::swap(device, probe.device);
-	std::swap(ctrlInterfaceNumber, probe.ctrlInterfaceNumber);
-	std::swap(dataInterfaceNumber, probe.dataInterfaceNumber);
-	std::swap(txEndpoint, probe.txEndpoint);
-	std::swap(rxEndpoint, probe.rxEndpoint);
+	device.swap(probe.device);
 	std::swap(_spiBus, probe._spiBus);
 	std::swap(_spiDevice, probe._spiDevice);
-}
-
-void bmp_t::writePacket(const std::string_view &packet) const
-{
-	console.debug("Remote write: "sv, packet);
-	if (!device.writeBulk(txEndpoint, packet.data(), static_cast<int32_t>(packet.length())))
-		throw bmpCommsError_t{};
-}
-
-std::string bmp_t::readPacket() const
-{
-	std::array<char, maxPacketSize + 1U> packet{};
-	// Read back what we can and check we got a valid response packet
-	if (!device.readBulk(rxEndpoint, packet.data(), maxPacketSize) || packet[0] != '&')
-		throw bmpCommsError_t{};
-	// Figure out how long that is (minus the beginning '&' and ending '#')
-	const auto length{std::strlen(packet.data() + 1U) - 1U};
-	// Make a new std::string of an appropriate length
-	std::string result(length + 1U, '\0');
-	// And copy the result string in, returning it
-	std::memcpy(result.data(), packet.data() + 1U, length);
-	console.debug("Remote read: "sv, result);
-	return result;
 }
 
 const char *bmpCommsError_t::what() const noexcept

--- a/src/bmpflash.cxx
+++ b/src/bmpflash.cxx
@@ -44,7 +44,7 @@ namespace bmpflash
 	std::vector<usbDevice_t> devices{};
 	for (auto device : context.deviceList())
 	{
-		if (device.vid() == 0x1d50U && device.pid() == 0x6018U)
+		if (device.vid() == bmp_t::vid && device.pid() == bmp_t::pid)
 		{
 			console.info("Found BMP at USB address "sv, device.busNumber(), '-', device.portNumber());
 			devices.emplace_back(std::move(device));

--- a/src/include/bmp.hxx
+++ b/src/include/bmp.hxx
@@ -51,6 +51,8 @@ private:
 	bmp_t() noexcept = default;
 
 public:
+	constexpr static uint16_t vid{0x1d50U};
+	constexpr static uint16_t pid{0x6018U};
 	constexpr static size_t maxPacketSize{1024U};
 
 	bmp_t(const usbDevice_t &usbDevice);

--- a/src/include/libusb/serialInterface.hxx
+++ b/src/include/libusb/serialInterface.hxx
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-FileCopyrightText: 2023 1BitSquared <info@1bitsquared.com>
+// SPDX-FileContributor: Written by Rachel Mant <git@dragonmux.network>
+#ifndef SERIAL_INTERFACE_HXX
+#define SERIAL_INTERFACE_HXX
+
+#include "usbDevice.hxx"
+
+struct serialInterface_t
+{
+private:
+	usbDeviceHandle_t device{};
+	uint8_t ctrlInterfaceNumber{UINT8_MAX};
+	uint8_t dataInterfaceNumber{UINT8_MAX};
+	uint8_t txEndpoint{};
+	uint8_t rxEndpoint{};
+
+public:
+	serialInterface_t() noexcept = default;
+	serialInterface_t(const usbDevice_t &usbDevice);
+	serialInterface_t(const serialInterface_t &) noexcept = delete;
+	serialInterface_t(serialInterface_t &&probe) noexcept : serialInterface_t{} { swap(probe); }
+	~serialInterface_t() noexcept;
+	serialInterface_t &operator =(const serialInterface_t &) noexcept = delete;
+
+	serialInterface_t &operator =(serialInterface_t &&interface) noexcept
+	{
+		swap(interface);
+		return *this;
+	}
+
+	[[nodiscard]] bool valid() const noexcept { return device.valid() && txEndpoint && rxEndpoint; }
+	void swap(serialInterface_t &interface) noexcept;
+
+	void writePacket(const std::string_view &packet) const;
+	[[nodiscard]] std::string readPacket() const;
+};
+
+#endif /*SERIAL_INTERFACE_HXX*/

--- a/src/include/windows/serialInterface.hxx
+++ b/src/include/windows/serialInterface.hxx
@@ -5,12 +5,15 @@
 #define SERIAL_INTERFACE_HXX
 
 #include <windows.h>
+#include <string_view>
 #include "usbDevice.hxx"
 
 struct serialInterface_t
 {
 private:
 	HANDLE device{INVALID_HANDLE_VALUE};
+
+	void handleDeviceError(const std::string_view operation) noexcept;
 
 public:
 	serialInterface_t() noexcept = default;

--- a/src/include/windows/serialInterface.hxx
+++ b/src/include/windows/serialInterface.hxx
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-FileCopyrightText: 2023 1BitSquared <info@1bitsquared.com>
+// SPDX-FileContributor: Written by Rachel Mant <git@dragonmux.network>
+#ifndef SERIAL_INTERFACE_HXX
+#define SERIAL_INTERFACE_HXX
+
+#include <windows.h>
+#include "usbDevice.hxx"
+
+struct serialInterface_t
+{
+private:
+	HANDLE device{INVALID_HANDLE_VALUE};
+
+public:
+	serialInterface_t() noexcept = default;
+	serialInterface_t(const usbDevice_t &usbDevice);
+	serialInterface_t(const serialInterface_t &) noexcept = delete;
+	serialInterface_t(serialInterface_t &&probe) noexcept : serialInterface_t{} { swap(probe); }
+	~serialInterface_t() noexcept;
+	serialInterface_t &operator =(const serialInterface_t &) noexcept = delete;
+
+	serialInterface_t &operator =(serialInterface_t &&interface) noexcept
+	{
+		swap(interface);
+		return *this;
+	}
+
+	[[nodiscard]] bool valid() const noexcept { return device != INVALID_HANDLE_VALUE; }
+	void swap(serialInterface_t &interface) noexcept;
+
+	void writePacket(const std::string_view &packet) const;
+	[[nodiscard]] std::string readPacket() const;
+};
+
+#endif /*SERIAL_INTERFACE_HXX*/

--- a/src/libusb/serialInterface.cxx
+++ b/src/libusb/serialInterface.cxx
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-FileCopyrightText: 2023 1BitSquared <info@1bitsquared.com>
+// SPDX-FileContributor: Written by Rachel Mant <git@dragonmux.network>
+
+#include <cstring>
+#include <substrate/console>
+#include <substrate/index_sequence>
+#include <substrate/span>
+#include "libusb/serialInterface.hxx"
+#include "bmp.hxx"
+
+using substrate::console;
+using usb::descriptors::usbClass_t;
+using cdcCommsSubclass_t = usb::descriptors::subclasses::cdcComms_t;
+using cdcCommsProtocol_t = usb::descriptors::protocols::cdcComms_t;
+using usb::descriptors::cdc::functionalDescriptor_t;
+using usb::descriptors::cdc::callManagementDescriptor_t;
+using cdcRequest_t = usb::types::cdc::request_t;
+using usb::types::cdc::controlLines_t;
+
+template<typename descriptor_t> auto descriptorFromSpan(const substrate::span<const uint8_t> &data) noexcept
+{
+	descriptor_t result{};
+	// Check there's at least enough data to fill the structure
+	if (data.size() < sizeof(result))
+		return result;
+	// Copy the necessary data and return it
+	std::memcpy(&result, data.data(), sizeof(result));
+	return result;
+}
+
+uint8_t locateDataInterface(const substrate::span<const uint8_t> &descriptorData) noexcept
+{
+	using usb::descriptors::cdc::descriptorType_t;
+	using usb::descriptors::cdc::descriptorSubtype_t;
+	size_t offset{};
+	// Iterate through the descriptor data
+	for (; offset < descriptorData.size(); )
+	{
+		// Safely unpack the next descriptor
+		auto descriptor{descriptorFromSpan<functionalDescriptor_t>(descriptorData.subspan(offset))};
+		// Check if it's a call management descriptor
+		if (descriptor.length == sizeof(callManagementDescriptor_t) &&
+			descriptor.type == descriptorType_t::interface &&
+			descriptor.subtype == descriptorSubtype_t::callManagement)
+		{
+			console.debug("Found CDC Call Management descriptor in extra data at +"sv, offset);
+			// Try unpacking the descriptor
+			auto callManagement{descriptorFromSpan<callManagementDescriptor_t>(descriptorData.subspan(offset))};
+			// If the length is 0, unpacking failed so bail out
+			if (!callManagement.length)
+				break;
+			console.debug("Found GDB server data interface number: "sv, callManagement.dataInterface);
+			// Otherwise, we've got our data interface!
+			return callManagement.dataInterface;
+		}
+		// Try to increment the offset by the length and check the length's not 0
+		// (if it is, unpacking failed so we should bail out)
+		offset += descriptor.length;
+		if (!descriptor.length)
+			break;
+	}
+	return UINT8_MAX;
+}
+
+std::pair<uint8_t, uint8_t> extractGDBInterface(const usbDeviceHandle_t &device, const usbConfiguration_t &config)
+{
+	// Iterate through the interfaces the configuration defines
+	for (const auto idx : substrate::indexSequence_t{config.interfaces()})
+	{
+		// Get each interface and inspect the first alt-mode
+		const auto interface{config.interface(idx)};
+		if (!interface.valid())
+			break;
+		const auto firstAltMode{interface.altMode(0)};
+		if (!firstAltMode.valid())
+			break;
+
+		// Look for interfaces implementing CDC ACM
+		if (firstAltMode.interfaceClass() != usbClass_t::cdcComms ||
+			firstAltMode.interfaceSubClass<cdcCommsSubclass_t>() != cdcCommsSubclass_t::abstractControl ||
+			firstAltMode.interfaceProtocol<cdcCommsProtocol_t>() != cdcCommsProtocol_t::none)
+			continue;
+
+		// Now grab the interface description string and check it matches the GDB server interface string
+		const auto ifaceName{device.readStringDescriptor(firstAltMode.interfaceIndex())};
+		console.debug("Found CDC ACM interface: "sv, ifaceName);
+		if (ifaceName != "Black Magic GDB Server"sv)
+			continue;
+		console.debug("Found GDB server interface at index "sv, idx, " ("sv, firstAltMode.interfaceNumber(), ')');
+
+		// Found it! Now parse the CDC functional descriptors that follow to find the data interface number
+		return {firstAltMode.interfaceNumber(), locateDataInterface(firstAltMode.extraDescriptors())};
+	}
+	return {UINT8_MAX, UINT8_MAX};
+}
+
+serialInterface_t::serialInterface_t(const usbDevice_t &usbDevice) : device{usbDevice.open()}
+{
+	// To figure out the endpoints for the GDB serial port, first grab the active configuration
+	const auto config{usbDevice.activeConfiguration()};
+	if (!config.valid())
+		return;
+	// Then hunt through the descriptors looking for the data interface number
+	std::tie(ctrlInterfaceNumber, dataInterfaceNumber) = extractGDBInterface(device, config);
+	// Check for errors finding the data interface
+	if (dataInterfaceNumber == UINT8_MAX)
+	{
+		console.error("Failed to find GDB server data interface"sv);
+		return;
+	}
+
+	// Re-iterate the interface list to find the data interface
+	for (const auto idx : substrate::indexSequence_t{config.interfaces()})
+	{
+		// Get each interface and inspect the first alt-mode
+		const auto interface{config.interface(idx)};
+		// Check that the interface is valid, skip if not
+		if (!interface.valid())
+			continue;
+		const auto firstAltMode{interface.altMode(0)};
+		// Check that the mode is valid, skip if not
+		if (!firstAltMode.valid())
+			continue;
+
+		// Check if the interface matches the data interface index
+		if (firstAltMode.interfaceNumber() != dataInterfaceNumber)
+			continue;
+
+		// We've got a match, so now check how many endpoints are reported
+		if (firstAltMode.endpoints() != 2U)
+		{
+			console.error("Probe descriptors are invalid"sv);
+			return;
+		}
+		// And iterate through them to extract the addresses
+		for (const auto epIndex : substrate::indexSequence_t{2U})
+		{
+			const auto endpoint{firstAltMode.endpoint(epIndex)};
+			if (endpoint.direction() == endpointDir_t::controllerOut)
+				txEndpoint = endpoint.address();
+			else
+				rxEndpoint = endpoint.address();
+		}
+		break;
+	}
+	// Validate the endpoint IDs and claim the interface, then, having claimed the interface
+	// ask it to become active by sending a SET_CONTROL_LINE_STATE control request via
+	// the associated CDC control interface}
+	if (!txEndpoint || !rxEndpoint || !device.claimInterface(ctrlInterfaceNumber) || !device.claimInterface(dataInterfaceNumber) ||
+		!device.writeControl({recipient_t::interface, request_t::typeClass}, uint8_t(cdcRequest_t::setControlLineState),
+			controlLines_t::dtrPresent | controlLines_t::rtsActivate, ctrlInterfaceNumber, nullptr))
+	{
+		// If either of them are bad, we couldn't claim the interface, or we couldn't send the control request, invalidate both.
+		txEndpoint = 0U;
+		rxEndpoint = 0U;
+	}
+	// Having adjusted the line state, try to do a read of the serial state notification which will be sat in the buffer
+	std::array<uint8_t, 10U> serialState{};
+	static_cast<void>(device.readBulk(rxEndpoint, serialState.data(), static_cast<int32_t>(serialState.size()), 100ms));
+}
+
+serialInterface_t::~serialInterface_t() noexcept
+{
+	if (ctrlInterfaceNumber != UINT8_MAX)
+		// Send a SET_CONTROL_LINE_STATE control request to reset the interface
+		static_cast<void>(device.writeControl({recipient_t::interface, request_t::typeClass},
+			uint8_t(cdcRequest_t::setControlLineState), 0U, ctrlInterfaceNumber, nullptr));
+	if (dataInterfaceNumber != UINT8_MAX)
+		// Release the data interface
+		static_cast<void>(device.releaseInterface(dataInterfaceNumber));
+	if (ctrlInterfaceNumber != UINT8_MAX)
+		// Release the data interface
+		static_cast<void>(device.releaseInterface(ctrlInterfaceNumber));
+}
+
+void serialInterface_t::swap(serialInterface_t &interface) noexcept
+{
+	device.swap(interface.device);
+	std::swap(ctrlInterfaceNumber, interface.ctrlInterfaceNumber);
+	std::swap(dataInterfaceNumber, interface.dataInterfaceNumber);
+	std::swap(txEndpoint, interface.txEndpoint);
+	std::swap(rxEndpoint, interface.rxEndpoint);
+}
+
+void serialInterface_t::writePacket(const std::string_view &packet) const
+{
+	console.debug("Remote write: "sv, packet);
+	if (!device.writeBulk(txEndpoint, packet.data(), static_cast<int32_t>(packet.length())))
+		throw bmpCommsError_t{};
+}
+
+std::string serialInterface_t::readPacket() const
+{
+	std::array<char, bmp_t::maxPacketSize + 1U> packet{};
+	// Read back what we can and check we got a valid response packet
+	if (!device.readBulk(rxEndpoint, packet.data(), bmp_t::maxPacketSize) || packet[0] != '&')
+		throw bmpCommsError_t{};
+	// Figure out how long that is (minus the beginning '&' and ending '#')
+	const auto length{std::strlen(packet.data() + 1U) - 1U};
+	// Make a new std::string of an appropriate length
+	std::string result(length + 1U, '\0');
+	// And copy the result string in, returning it
+	std::memcpy(result.data(), packet.data() + 1U, length);
+	console.debug("Remote read: "sv, result);
+	return result;
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -164,7 +164,9 @@ bmpflashSrc = [
 	'spiFlash.cxx', versionHeader,
 ]
 
-if host_machine.system() != 'windows'
+if host_machine.system() == 'windows'
+	bmpflashSrc += 'windows/serialInterface.cxx'
+else
 	bmpflashSrc += 'libusb/serialInterface.cxx'
 endif
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -164,6 +164,10 @@ bmpflashSrc = [
 	'spiFlash.cxx', versionHeader,
 ]
 
+if host_machine.system() != 'windows'
+	bmpflashSrc += 'libusb/serialInterface.cxx'
+endif
+
 subdir('elf')
 
 bmpflashCppArgs = ['-D_FORTIFY_SOURCE=2']

--- a/src/windows/serialInterface.cxx
+++ b/src/windows/serialInterface.cxx
@@ -59,6 +59,26 @@ public:
 	}
 
 	[[nodiscard]] bool valid() const noexcept { return handle != INVALID_HANDLE_VALUE; }
+
+	[[nodiscard]] std::string readStringKey(std::string_view keyName) const
+	{
+		DWORD valueLength{0U};
+		if (const auto result{RegGetValue(handle, nullptr, keyName.data(), RRF_RT_REG_SZ, nullptr, nullptr, &valueLength)};
+			result != ERROR_SUCCESS && result != ERROR_MORE_DATA)
+		{
+			displayError(result, "retrieve value for key"sv, keyName);
+			return {};
+		}
+
+		std::string value(valueLength, '\0');
+		if (const auto result{RegGetValue(handle, nullptr, keyName.data(), RRF_RT_REG_SZ, nullptr, value.data(),
+			&valueLength)}; result != ERROR_SUCCESS)
+		{
+			displayError(result, "retrieve value for key"sv, keyName);
+			return {};
+		}
+		return value;
+	}
 };
 
 serialInterface_t::serialInterface_t(const usbDevice_t &usbDevice)

--- a/src/windows/serialInterface.cxx
+++ b/src/windows/serialInterface.cxx
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // SPDX-FileCopyrightText: 2023 1BitSquared <info@1bitsquared.com>
 // SPDX-FileContributor: Written by Rachel Mant <git@dragonmux.network>
+#include <substrate/console>
 #include "windows/serialInterface.hxx"
 #include "bmp.hxx"
+
+using substrate::console;
 
 [[nodiscard]] std::string serialForDevice(const usbDevice_t &device)
 {
@@ -12,6 +15,51 @@
 	const auto handle{device.open()};
 	return handle.readStringDescriptor(serialIndex);
 }
+
+void displayError(const LSTATUS error, const std::string_view operation, const std::string_view path)
+{
+	char *message{nullptr};
+	FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, nullptr,
+		error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), reinterpret_cast<char *>(&message), 0, nullptr);
+	console.error("Failed to "sv, operation, ' ', path, ", got error "sv, asHex_t<8, '0'>{uint32_t(error)},
+		": "sv, message);
+	LocalFree(message);
+}
+
+struct hklmRegistryKey_t
+{
+private:
+	HKEY handle{static_cast<HKEY>(INVALID_HANDLE_VALUE)};
+
+public:
+	hklmRegistryKey_t() noexcept = default;
+	hklmRegistryKey_t(const hklmRegistryKey_t &) = delete;
+	hklmRegistryKey_t operator =(const hklmRegistryKey_t &) = delete;
+
+	hklmRegistryKey_t(const std::string &path, const REGSAM permissions) :
+		handle
+		{
+			[&]()
+			{
+				auto keyHandle{static_cast<HKEY>(INVALID_HANDLE_VALUE)};
+				if (const auto result{RegOpenKeyEx(HKEY_LOCAL_MACHINE, path.c_str(), 0, permissions, &keyHandle)};
+					result != ERROR_SUCCESS)
+				{
+					displayError(result, "open registry key"sv, path);
+					return static_cast<HKEY>(INVALID_HANDLE_VALUE);
+				}
+				return keyHandle;
+			}()
+		} { }
+
+	~hklmRegistryKey_t() noexcept
+	{
+		if (handle != INVALID_HANDLE_VALUE)
+			RegCloseKey(handle);
+	}
+
+	[[nodiscard]] bool valid() const noexcept { return handle != INVALID_HANDLE_VALUE; }
+};
 
 serialInterface_t::serialInterface_t(const usbDevice_t &usbDevice)
 {

--- a/src/windows/serialInterface.cxx
+++ b/src/windows/serialInterface.cxx
@@ -142,6 +142,22 @@ serialInterface_t::serialInterface_t(const usbDevice_t &usbDevice)
 {
 }
 
+void serialInterface_t::handleDeviceError(const std::string_view operation) noexcept
+{
+	// Get the last error that occured
+	const auto error{GetLastError()};
+	char *message{nullptr};
+	// Ask Windows to please tell us what the error value we have means, and allocate + store it in `message`
+	FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, nullptr,
+		error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), reinterpret_cast<char *>(&message), 0, nullptr);
+	console.error("Failed to "sv, operation, " ("sv, asHex_t<8, '0'>{error}, "): "sv, message);
+	// Clean up properly after ourselves
+	LocalFree(message);
+	if (device != INVALID_HANDLE_VALUE)
+		CloseHandle(device);
+	device = INVALID_HANDLE_VALUE;
+}
+
 serialInterface_t::~serialInterface_t() noexcept
 {
 }

--- a/src/windows/serialInterface.cxx
+++ b/src/windows/serialInterface.cxx
@@ -202,6 +202,10 @@ serialInterface_t::serialInterface_t(const usbDevice_t &usbDevice) : device
 	timeouts.WriteTotalTimeoutMultiplier = 10;
 	if (!SetCommTimeouts(device, &timeouts))
 		handleDeviceError("set communications timeouts for device"sv);
+
+	// Having adjusted the line state, try to do a read of the serial state notification which will be sat in the buffer
+	std::array<uint8_t, 10U> serialState{};
+	static_cast<void>(ReadFile(device, serialState.data(), serialState.size(), nullptr, nullptr));
 }
 
 serialInterface_t::~serialInterface_t() noexcept

--- a/src/windows/serialInterface.cxx
+++ b/src/windows/serialInterface.cxx
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-FileCopyrightText: 2023 1BitSquared <info@1bitsquared.com>
+// SPDX-FileContributor: Written by Rachel Mant <git@dragonmux.network>
+#include "windows/serialInterface.hxx"
+#include "bmp.hxx"
+
+serialInterface_t::serialInterface_t(const usbDevice_t &usbDevice)
+{
+}
+
+serialInterface_t::~serialInterface_t() noexcept
+{
+}
+
+void serialInterface_t::swap(serialInterface_t &interface) noexcept
+{
+	std::swap(device, interface.device);
+}
+
+void serialInterface_t::writePacket(const std::string_view &packet) const
+{
+}
+
+std::string serialInterface_t::readPacket() const
+{
+	return "";
+}

--- a/src/windows/serialInterface.cxx
+++ b/src/windows/serialInterface.cxx
@@ -78,7 +78,7 @@ public:
 	{
 		DWORD valueLength{0U};
 		// Figure out how long the value is, stored into `valueLength`
-		if (const auto result{RegGetValue(handle, nullptr, keyName.data(), RRF_RT_REG_SZ, nullptr, nullptr, &valueLength)};
+		if (const auto result{RegGetValueA(handle, nullptr, keyName.data(), RRF_RT_REG_SZ, nullptr, nullptr, &valueLength)};
 			result != ERROR_SUCCESS && result != ERROR_MORE_DATA)
 		{
 			displayError(result, "retrieve value for key"sv, keyName);
@@ -88,12 +88,16 @@ public:
 		// Allocate a string long enough that has been prefilled with nul characters
 		std::string value(valueLength, '\0');
 		// Retrieve the actual value of the key now we have all the inforamtion needed to do so
-		if (const auto result{RegGetValue(handle, nullptr, keyName.data(), RRF_RT_REG_SZ, nullptr, value.data(),
+		if (const auto result{RegGetValueA(handle, nullptr, keyName.data(), RRF_RT_REG_SZ, nullptr, value.data(),
 			&valueLength)}; result != ERROR_SUCCESS)
 		{
 			displayError(result, "retrieve value for key"sv, keyName);
 			return {};
 		}
+
+		// After, trim trailing nul characters as there will be 1 or 2
+		while (!value.empty() && value.back() == '\0')
+			value.erase(value.end() - 1U);
 		return value;
 	}
 };

--- a/src/windows/serialInterface.cxx
+++ b/src/windows/serialInterface.cxx
@@ -218,6 +218,9 @@ void serialInterface_t::handleDeviceError(const std::string_view operation) noex
 {
 	// Get the last error that occured
 	const auto error{GetLastError()};
+	// If there is no error and no device (we failed to look up the device node), return early
+	if (error == ERROR_SUCCESS && device == INVALID_HANDLE_VALUE)
+		return;
 	char *message{nullptr};
 	// Ask Windows to please tell us what the error value we have means, and allocate + store it in `message`
 	FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, nullptr,

--- a/src/windows/serialInterface.cxx
+++ b/src/windows/serialInterface.cxx
@@ -24,10 +24,11 @@ constexpr static auto uncDeviceSuffix{"\\\\.\\"sv};
 
 void displayError(const LSTATUS error, const std::string_view operation, const std::string_view path)
 {
-	char *message{nullptr};
+	wchar_t *message{nullptr};
 	// Ask Windows to please tell us what the error value we have means, and allocate + store it in `message`
-	FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, nullptr,
-		error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), reinterpret_cast<char *>(&message), 0, nullptr);
+	FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, nullptr,
+		static_cast<DWORD>(error), MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), reinterpret_cast<wchar_t *>(&message), 0,
+		nullptr);
 	console.error("Failed to "sv, operation, ' ', path, ", got error "sv, asHex_t<8, '0'>{uint32_t(error)},
 		": "sv, message);
 	// Clean up properly after ourselves
@@ -225,10 +226,10 @@ void serialInterface_t::handleDeviceError(const std::string_view operation) noex
 	// If there is no error and no device (we failed to look up the device node), return early
 	if (error == ERROR_SUCCESS && device == INVALID_HANDLE_VALUE)
 		return;
-	char *message{nullptr};
+	wchar_t *message{nullptr};
 	// Ask Windows to please tell us what the error value we have means, and allocate + store it in `message`
-	FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, nullptr,
-		error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), reinterpret_cast<char *>(&message), 0, nullptr);
+	FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, nullptr,
+		error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), reinterpret_cast<wchar_t *>(&message), 0, nullptr);
 	console.error("Failed to "sv, operation, " ("sv, asHex_t<8, '0'>{error}, "): "sv, message);
 	// Clean up properly after ourselves
 	LocalFree(message);

--- a/src/windows/serialInterface.cxx
+++ b/src/windows/serialInterface.cxx
@@ -233,6 +233,16 @@ void serialInterface_t::swap(serialInterface_t &interface) noexcept
 
 void serialInterface_t::writePacket(const std::string_view &packet) const
 {
+	console.debug("Remote write: "sv, packet);
+	DWORD written{0};
+	for (size_t offset{0}; offset < packet.length(); offset += written)
+	{
+		if (!WriteFile(device, packet.data() + offset, static_cast<DWORD>(packet.length() - offset), &written, nullptr))
+		{
+			console.error("Write to device failed ("sv, GetLastError(), "), written "sv, offset, " bytes");
+			throw bmpCommsError_t{};
+		}
+	}
 }
 
 std::string serialInterface_t::readPacket() const

--- a/src/windows/serialInterface.cxx
+++ b/src/windows/serialInterface.cxx
@@ -4,6 +4,15 @@
 #include "windows/serialInterface.hxx"
 #include "bmp.hxx"
 
+[[nodiscard]] std::string serialForDevice(const usbDevice_t &device)
+{
+	const auto serialIndex{device.serialNumberIndex()};
+	if (serialIndex == 0)
+		return {};
+	const auto handle{device.open()};
+	return handle.readStringDescriptor(serialIndex);
+}
+
 serialInterface_t::serialInterface_t(const usbDevice_t &usbDevice)
 {
 }

--- a/src/windows/serialInterface.cxx
+++ b/src/windows/serialInterface.cxx
@@ -12,9 +12,12 @@ constexpr static auto uncDeviceSuffix{"\\\\.\\"sv};
 
 [[nodiscard]] std::string serialForDevice(const usbDevice_t &device)
 {
+	// Grab the serial number string descriptor index
 	const auto serialIndex{device.serialNumberIndex()};
+	// If it's invalid (0), return an invalid string
 	if (serialIndex == 0)
 		return {};
+	// Otherwise open a handle on the device and try reading the string descriptor
 	const auto handle{device.open()};
 	return handle.readStringDescriptor(serialIndex);
 }
@@ -22,13 +25,17 @@ constexpr static auto uncDeviceSuffix{"\\\\.\\"sv};
 void displayError(const LSTATUS error, const std::string_view operation, const std::string_view path)
 {
 	char *message{nullptr};
+	// Ask Windows to please tell us what the error value we have means, and allocate + store it in `message`
 	FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, nullptr,
 		error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), reinterpret_cast<char *>(&message), 0, nullptr);
 	console.error("Failed to "sv, operation, ' ', path, ", got error "sv, asHex_t<8, '0'>{uint32_t(error)},
 		": "sv, message);
+	// Clean up properly after ourselves
 	LocalFree(message);
 }
 
+// This is a lightweight RAII wrapper around a HKEY on the HKLM registry hive.
+// It could be generalised trivially to any kind of registry key, but it's not necessary for bmpflash.
 struct hklmRegistryKey_t
 {
 private:
@@ -39,12 +46,14 @@ public:
 	hklmRegistryKey_t(const hklmRegistryKey_t &) = delete;
 	hklmRegistryKey_t operator =(const hklmRegistryKey_t &) = delete;
 
+	// `path` should be a path somewhere inside the HKLM registry hive.
 	hklmRegistryKey_t(const std::string &path, const REGSAM permissions) :
 		handle
 		{
 			[&]()
 			{
 				auto keyHandle{static_cast<HKEY>(INVALID_HANDLE_VALUE)};
+				// Try opening the requested key
 				if (const auto result{RegOpenKeyEx(HKEY_LOCAL_MACHINE, path.c_str(), 0, permissions, &keyHandle)};
 					result != ERROR_SUCCESS)
 				{
@@ -57,15 +66,18 @@ public:
 
 	~hklmRegistryKey_t() noexcept
 	{
+		// Close the key if we're destructing a valid object that holds a handle to one
 		if (handle != INVALID_HANDLE_VALUE)
 			RegCloseKey(handle);
 	}
 
 	[[nodiscard]] bool valid() const noexcept { return handle != INVALID_HANDLE_VALUE; }
 
+	// Reads the string key `keyName` from the registry
 	[[nodiscard]] std::string readStringKey(std::string_view keyName) const
 	{
 		DWORD valueLength{0U};
+		// Figure out how long the value is, stored into `valueLength`
 		if (const auto result{RegGetValue(handle, nullptr, keyName.data(), RRF_RT_REG_SZ, nullptr, nullptr, &valueLength)};
 			result != ERROR_SUCCESS && result != ERROR_MORE_DATA)
 		{
@@ -73,7 +85,9 @@ public:
 			return {};
 		}
 
+		// Allocate a string long enough that has been prefilled with nul characters
 		std::string value(valueLength, '\0');
+		// Retrieve the actual value of the key now we have all the inforamtion needed to do so
 		if (const auto result{RegGetValue(handle, nullptr, keyName.data(), RRF_RT_REG_SZ, nullptr, value.data(),
 			&valueLength)}; result != ERROR_SUCCESS)
 		{
@@ -86,6 +100,7 @@ public:
 
 [[nodiscard]] std::string readKeyFromPath(const std::string &subpath, const std::string_view keyName)
 {
+	// Open the registry key that should represent the required subpath for the BMP
 	const hklmRegistryKey_t keyPathHandle
 	{
 		fmt::format("SYSTEM\\CurrentControlSet\\Enum\\USB\\VID_{:04X}&PID_{:04X}{}"sv,
@@ -93,24 +108,29 @@ public:
 	};
 	if (!keyPathHandle.valid())
 		return {};
+	// Retrieve the string key requested
 	return keyPathHandle.readStringKey(keyName);
 }
 
 [[nodiscard]] std::string findBySerialNumber(const usbDevice_t &device)
 {
+	// Start by getting the serial number of the device
 	const auto serialNumber{serialForDevice(device)};
 	if (serialNumber.empty())
 		return {};
 
+	// Now look up the prefix for the entry in the interface 0s tree
 	const auto prefix{readKeyFromPath(fmt::format("\\{}"sv, serialNumber), "ParentIdPrefix"sv)};
 	if (prefix.empty())
 		return {};
 	console.debug("Device registry path prefix: "sv, prefix);
 
+	// Look up the `COMn` device node name associated with the target interface
 	auto portName{readKeyFromPath(fmt::format("&MI_00\\{}&0000\\Device Parameters"sv, prefix), "PortName"sv)};
 	if (portName.empty())
 		return {};
 
+	// If it is not already a proper UNC device path, turn it into one
 	if (std::string_view{portName}.substr(0, uncDeviceSuffix.size()) != uncDeviceSuffix)
 		portName.insert(0, uncDeviceSuffix);
 


### PR DESCRIPTION
This PR refactors the low-level IO so we can re-target it while using the same bmp_t logic. This is done to provide proper support for Windows in the utility as libusb is unable to unbind usbser.sys and take over controlling the GDB serial interface directly due to architectural limitations imposed by Windows.

The result is using Win32 API calls to provide serial IO using the `\\.\COMn` interface representing the GDB interface on BMP on Windows, and using libusb to provide serial IO via the libusb_device on macOS and Linux. This new interface for Windows is slower by nature of how the APIs provided work (we can't read by USB packet, the serial interface stuff strips all that framing entirely, degrading performance), but at least this removes the need to Zadig over the interface to WinUSB to make the utility work and then having to Zadig it back for everything else.

This should be the last item that had to be fixed to allow us to do a v1.0 release.