### PR TITLE
Fix: SFDP conformance checks

### DIFF
--- a/src/actions.cxx
+++ b/src/actions.cxx
@@ -188,7 +188,7 @@ namespace bmpflash
 			return false;
 
 		// Ask for the SFDP data and display it then clean up
-		sfdp::readAndDisplay(*probe);
+		sfdp::readAndDisplay(*probe, sfdpArguments["display-raw"sv] != nullptr);
 		return probe->end();
 	}
 

--- a/src/include/options.hxx
+++ b/src/include/options.hxx
@@ -59,6 +59,19 @@ namespace bmpflash
 		)
 	};
 
+	constexpr static auto sfdpOptions
+	{
+		options
+		(
+			deviceOptions,
+			option_t
+			{
+				optionFlagPair_t{"-r"sv, "--display-raw"sv},
+				"Dispaly the raw SFDP data read from the device as it's read"sv
+			}
+		)
+	};
+
 	constexpr static auto provisioningOptions{options(serialOption, fileOption)};
 	constexpr static auto generalFlashOptions{options(deviceOptions, fileOption)};
 
@@ -74,7 +87,7 @@ namespace bmpflash
 			{
 				"sfdp"sv,
 				"Display the SFDP (Serial Flash Discoverable Parameters) information for a Flash chip"sv,
-				deviceOptions,
+				sfdpOptions,
 			},
 			{
 				"provision"sv,

--- a/src/include/sfdp.hxx
+++ b/src/include/sfdp.hxx
@@ -10,7 +10,7 @@ namespace bmpflash::sfdp
 {
 	using bmpflash::spiFlash::spiFlash_t;
 
-	bool readAndDisplay(const bmp_t &probe);
+	bool readAndDisplay(const bmp_t &probe, bool displayRaw);
 	std::optional<spiFlash_t> read(const bmp_t &probe);
 } // namespace bmpflash::sfdp
 

--- a/src/include/sfdpInternal.hxx
+++ b/src/include/sfdpInternal.hxx
@@ -63,7 +63,8 @@ namespace bmpflash::sfdp
 
 		[[nodiscard]] uint16_t jedecParameterID() const noexcept
 			{ return static_cast<uint16_t>((jedecParameterIDHigh << 8U) | jedecParameterIDLow); }
-		[[nodiscard]] size_t tableLength() const noexcept { return static_cast<size_t>(tableLengthInU32s) * 4U; }
+		[[nodiscard]] size_t tableLength() const noexcept { return static_cast<size_t>(tableLengthInU32s * 4U); }
+		void validate() noexcept;
 	};
 
 	struct memoryDensity_t

--- a/src/include/sfdpInternal.hxx
+++ b/src/include/sfdpInternal.hxx
@@ -67,6 +67,29 @@ namespace bmpflash::sfdp
 		void validate() noexcept;
 	};
 
+	struct fastReadAndAddressing_t
+	{
+	private:
+		uint8_t data{};
+
+	public:
+		[[nodiscard]] bool supportsFastRead_1_1_2() const noexcept { return data & 0x01U; }
+		[[nodiscard]] bool supportsFastRead_1_1_4() const noexcept { return data & 0x40U; }
+		[[nodiscard]] bool supportsFastRead_1_2_2() const noexcept { return data & 0x10U; }
+		[[nodiscard]] bool supportsFastRead_1_4_4() const noexcept { return data & 0x20U; }
+
+		[[nodiscard]] uint8_t addressBytes() const
+		{
+			const auto bytes{static_cast<uint8_t>(data & 0x06U)};
+			if (bytes == 0x00U)
+				return 3U;
+			if (bytes == 0x04U)
+				return 4U;
+			// 0x02U is 3-or-4-bytes mode but we can't necessarily determine which the chip is in
+			throw std::range_error{"Address bytes value invalid or indeterminate"};
+		}
+	};
+
 	struct memoryDensity_t
 	{
 		std::array<uint8_t, 4> data{};
@@ -147,7 +170,7 @@ END_PACKED()
 	{
 		uint8_t value1{};
 		uint8_t sectorEraseOpcode{};
-		uint8_t value2{};
+		fastReadAndAddressing_t fastReadAndAddressing{};
 		uint8_t reserved1{};
 		memoryDensity_t flashMemoryDensity{};
 		timingsAndOpcode_t fastQuadIO{};

--- a/src/include/sfdpInternal.hxx
+++ b/src/include/sfdpInternal.hxx
@@ -114,10 +114,15 @@ END_PACKED()
 		uint8_t programmingTimingRatioAndPageSize{};
 		std::array<uint8_t, 3> eraseTimings;
 
-		[[nodiscard]] uint64_t pageSize() const noexcept
+		[[nodiscard]] uint32_t pageSize() const noexcept
 		{
+			// Extract the exponent, which by definition must be a value between 0 and 15
 			const auto pageSizeExponent{static_cast<uint8_t>(programmingTimingRatioAndPageSize >> 4U)};
-			return UINT64_C(1) << pageSizeExponent;
+			// If for some reason this is 0, return the default page size (256) instead
+			if (!pageSizeExponent)
+				return 256U;
+			// Exponentiate to get the real page size (0-64KiB)
+			return 1U << pageSizeExponent;
 		}
 	};
 

--- a/src/include/sfdpInternal.hxx
+++ b/src/include/sfdpInternal.hxx
@@ -50,6 +50,10 @@ namespace bmpflash::sfdp
 
 	struct parameterTableHeader_t
 	{
+	private:
+		[[nodiscard]] size_t lengthForVersion() const noexcept;
+
+	public:
 		uint8_t jedecParameterIDLow{};
 		uint8_t versionMinor{};
 		uint8_t versionMajor{};

--- a/src/include/sfdpInternal.hxx
+++ b/src/include/sfdpInternal.hxx
@@ -67,6 +67,28 @@ namespace bmpflash::sfdp
 		void validate() noexcept;
 	};
 
+	struct writeAndEraseGranularity_t
+	{
+	private:
+		uint8_t data{};
+
+	public:
+		[[nodiscard]] std::optional<uint8_t> volatileStatusWriteEnable() const noexcept
+		{
+			// Check if the status register requires any write enables
+			if (!(data & 0x08U))
+				return std::nullopt;
+			// Otherwise check if the device requires 0x06 as write enable
+			if (data & 0x10U)
+				return 0x06U;
+			// If not, then it's 0x50 as write enable
+			return 0x50U;
+		}
+
+		[[nodiscard]] bool supports4KiBErase() const noexcept
+			{ return (data & 0x03U) == 0x01U; }
+	};
+
 	struct fastReadAndAddressing_t
 	{
 	private:
@@ -168,7 +190,7 @@ END_PACKED()
 
 	struct basicParameterTable_t
 	{
-		uint8_t value1{};
+		writeAndEraseGranularity_t writeAndEraseGranularity{};
 		uint8_t sectorEraseOpcode{};
 		fastReadAndAddressing_t fastReadAndAddressing{};
 		uint8_t reserved1{};

--- a/src/include/spiFlash.hxx
+++ b/src/include/spiFlash.hxx
@@ -81,6 +81,10 @@ namespace bmpflash::spiFlash
 		pageRead = command(opcodeMode_t::with3BAddress, dataMode_t::dataIn, 0U, opcode_t::pageRead),
 	};
 
+	// NB: This technically invokes UB, however there's not really a better way to do this, so.
+	constexpr inline command_t operator |(const command_t &cmd, const uint8_t &opcode) noexcept
+		{ return static_cast<command_t>(uint16_t(cmd) | opcode); }
+
 	constexpr inline uint8_t spiStatusBusy{1};
 	constexpr inline uint8_t spiStatusWriteEnabled{2};
 

--- a/src/sfdp.cxx
+++ b/src/sfdp.cxx
@@ -238,12 +238,18 @@ namespace bmpflash::sfdp
 		if (actualLength == expectedLength)
 			return;
 
+		console.warn("Found mismatched basic parameters table length, got "sv, actualLength, ", expected "sv,
+			expectedLength);
 		// If the table is longer than it should be for the stated version, truncate it
 		if (actualLength > expectedLength)
+		{
+			console.warn("Adjusting table length to correct"sv);
 			tableLengthInU32s = static_cast<uint8_t>(expectedLength / 4U);
+		}
 		// Otherwise fix the version number to match the one for the actual length
 		else
 		{
+			console.warn("Adjusting table version number to correct"sv);
 			// 24 uint32_t's -> v1.8
 			if (actualLength == 96U)
 			{

--- a/src/sfdp.cxx
+++ b/src/sfdp.cxx
@@ -3,14 +3,18 @@
 // SPDX-FileContributor: Written by Rachel Mant <git@dragonmux.network>
 #include <cstddef>
 #include <cstdint>
+#include <cinttypes>
 #include <string_view>
+#include <array>
 #include <tuple>
+#include <optional>
 #include <substrate/console>
 #include <substrate/index_sequence>
 #include <substrate/indexed_iterator>
 #include <substrate/units>
 #include <substrate/span>
 #include "bmp.hxx"
+#include "spiFlash.hxx"
 #include "sfdp.hxx"
 #include "sfdpInternal.hxx"
 #include "units.hxx"

--- a/src/spiFlash.cxx
+++ b/src/spiFlash.cxx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // SPDX-FileCopyrightText: 2023 1BitSquared <info@1bitsquared.com>
 // SPDX-FileContributor: Written by Rachel Mant <git@dragonmux.network>
+#include <cstdint>
 #include <string_view>
 #include <substrate/console>
 #include <substrate/index_sequence>
@@ -33,7 +34,7 @@ namespace bmpflash::spiFlash
 		console.debug("Erasing sector at 0x"sv, asHex_t<6, '0'>{address});
 		// Start by erasing the block
 		if (!probe.runCommand(spiFlashCommand_t::writeEnable, 0U) ||
-			!probe.runCommand(spiFlashCommand_t::sectorErase, static_cast<uint32_t>(address)) ||
+			!probe.runCommand(spiFlashCommand_t::sectorErase | sectorEraseOpcode_, static_cast<uint32_t>(address)) ||
 			!waitFlashIdle(probe))
 		{
 			console.error("Failed to prepare SPI Flash block for writing"sv);


### PR DESCRIPTION
This PR addresses an issue found and reported by ALTracer on Discord where some devices report mismatching length and SFDP Basic Parameter Table version information. It was determined in the process that the length information is in fact correct and should be trusted in place of the version information when a conflict occurs and the length is shorter than it is expected to be, and the version trusted otherwise.

This PR implements new checks to verify the length information against the version information and correct whichever one is wrong, warning the user that this has had to happen in the process.

Additionally, this PR fixes a problem we spotted with the SPI Flash write process due to the sector erase opcode never being or'd in to the command sent. This would have meant that writes would only work with already empty devices.