### PR TITLE
Fix: libusb serial interface crashes on FreeBSD

### DIFF
--- a/src/include/usbDevice.hxx
+++ b/src/include/usbDevice.hxx
@@ -105,15 +105,19 @@ private:
 	[[nodiscard]] bool interruptTransfer(const uint8_t endpoint, const void *const bufferPtr,
 		const int32_t bufferLen, const milliseconds_t timeout) const noexcept
 	{
+		// libusb versions prior to v1.0.21 cannot take `nullptr` as their `transfer` parameter.
+		// FreeBSD's custom libusb implements API version v1.0.13 at time of writing, so we cannot make
+		// use of this ability to ignore the transfer byte count result.
+		int bytesTransferred{};
 		// The const-cast here is required becasue libusb is not const-correct. It is UB, but we cannot avoid it.
 		const auto result
 		{
 			libusb_interrupt_transfer(device, endpoint,
 				// NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-				const_cast<uint8_t *>(static_cast<const uint8_t *>(bufferPtr)), bufferLen, nullptr,
+				const_cast<uint8_t *>(static_cast<const uint8_t *>(bufferPtr)), bufferLen, &bytesTransferred,
 				static_cast<uint32_t>(timeout.count()))
 		};
-
+		// Check for outright failures and report them
 		if (result && result != LIBUSB_ERROR_TIMEOUT)
 		{
 			const auto endpointNumber{uint8_t(endpoint & 0x7FU)};
@@ -123,6 +127,9 @@ private:
 				direction == endpointDir_t::controllerIn ? "IN"sv : "OUT"sv,
 				", reason: "sv, libusb_error_name(result));
 		}
+		// Check if we moved less data than we expected, and warn if in debug mode if we did
+		if (result == 0 && bytesTransferred < bufferLen && console.showDebug())
+			console.warn("Interrupt transfer received "sv, bytesTransferred, " instead of the expected "sv, bufferLen);
 		return !result;
 	}
 

--- a/src/libusb/serialInterface.cxx
+++ b/src/libusb/serialInterface.cxx
@@ -137,6 +137,11 @@ serialInterface_t::serialInterface_t(const usbDevice_t &usbDevice) : device{usbD
 		for (const auto epIndex : substrate::indexSequence_t{2U})
 		{
 			const auto endpoint{firstAltMode.endpoint(epIndex)};
+			if (!endpoint.valid())
+			{
+				console.error("Probe interface missing a required endpoint (index "sv, epIndex, ')');
+				return;
+			}
 			if (endpoint.direction() == endpointDir_t::controllerOut)
 				txEndpoint = endpoint.address();
 			else


### PR DESCRIPTION
This PR addresses a series of crashes and issues identified by ALTracer on Discord when running the program on FreeBSD. This includes two API contract violations with libusb caused by their older interface implementation, and two crashes in bmpflash's logic.

With these fixes, bmpflash runs properly on FreeBSD and produces identical results to a Linux host.