### PR TITLE
Feature: Windows speed improvements

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -169,7 +169,7 @@ jobs:
         # Codecov no longer parses gcov files automatically
         run: |
           rm -rf build
-          meson setup build --prefix=$HOME/.local -Db_coverage=true --buildtype=debug
+          meson setup build --prefix=$HOME/.local -Db_coverage=true -Db_lto=false --buildtype=debug
           meson compile -C build
           meson test -C build
           ninja -C build coverage-xml

--- a/src/include/sfdpInternal.hxx
+++ b/src/include/sfdpInternal.hxx
@@ -80,9 +80,9 @@ namespace bmpflash::sfdp
 				return std::nullopt;
 			// Otherwise check if the device requires 0x06 as write enable
 			if (data & 0x10U)
-				return 0x06U;
+				return static_cast<uint8_t>(0x06U);
 			// If not, then it's 0x50 as write enable
-			return 0x50U;
+			return static_cast<uint8_t>(0x50U);
 		}
 
 		[[nodiscard]] bool supports4KiBErase() const noexcept

--- a/src/include/windows/serialInterface.hxx
+++ b/src/include/windows/serialInterface.hxx
@@ -17,7 +17,6 @@ private:
 
 	void handleDeviceError(std::string_view operation) noexcept;
 	void refillBuffer() const;
-	[[nodiscard]] char nextByte() const;
 
 public:
 	serialInterface_t() noexcept = default;

--- a/src/include/windows/serialInterface.hxx
+++ b/src/include/windows/serialInterface.hxx
@@ -16,6 +16,8 @@ private:
 	HANDLE device{INVALID_HANDLE_VALUE};
 
 	void handleDeviceError(std::string_view operation) noexcept;
+	void refillBuffer() const;
+	[[nodiscard]] char nextByte() const;
 
 public:
 	serialInterface_t() noexcept = default;

--- a/src/include/windows/serialInterface.hxx
+++ b/src/include/windows/serialInterface.hxx
@@ -4,6 +4,8 @@
 #ifndef SERIAL_INTERFACE_HXX
 #define SERIAL_INTERFACE_HXX
 
+#include <cstdint>
+#include <cstddef>
 #include <windows.h>
 #include <string_view>
 #include "usbDevice.hxx"
@@ -13,7 +15,7 @@ struct serialInterface_t
 private:
 	HANDLE device{INVALID_HANDLE_VALUE};
 
-	void handleDeviceError(const std::string_view operation) noexcept;
+	void handleDeviceError(std::string_view operation) noexcept;
 
 public:
 	serialInterface_t() noexcept = default;

--- a/src/libusb/serialInterface.cxx
+++ b/src/libusb/serialInterface.cxx
@@ -209,11 +209,10 @@ std::string serialInterface_t::readPacket() const
 	if (!device.readBulk(rxEndpoint, packet.data(), bmp_t::maxPacketSize) || packet[0] != '&')
 		throw bmpCommsError_t{};
 	// Figure out how long that is (minus the beginning '&' and ending '#')
-	const auto length{std::strlen(packet.data() + 1U) - 1U};
-	// Make a new std::string of an appropriate length
-	std::string result(length + 1U, '\0');
-	// And copy the result string in, returning it
-	std::memcpy(result.data(), packet.data() + 1U, length);
+	const auto length{std::strlen(packet.data() + 1U)};
+	packet[length] = '\0';
+	// Make a new std::string of an appropriate length, copying the data in to return it
+	std::string result{packet.data() + 1U, length};
 	console.debug("Remote read: "sv, result);
 	return result;
 }

--- a/src/windows/serialInterface.cxx
+++ b/src/windows/serialInterface.cxx
@@ -1,11 +1,18 @@
 // SPDX-License-Identifier: BSD-3-Clause
-// SPDX-FileCopyrightText: 2023 1BitSquared <info@1bitsquared.com>
+// SPDX-FileCopyrightText: 2023a-2024 1BitSquared <info@1bitsquared.com>
 // SPDX-FileContributor: Written by Rachel Mant <git@dragonmux.network>
+#include <cstdint>
+#include <cstddef>
+#include <array>
+#include <string>
+#include <string_view>
 #include <fmt/format.h>
 #include <substrate/console>
 #include "windows/serialInterface.hxx"
+#include "usbDevice.hxx"
 #include "bmp.hxx"
 
+using namespace std::literals::string_view_literals;
 using substrate::console;
 
 constexpr static auto uncDeviceSuffix{"\\\\.\\"sv};
@@ -65,6 +72,7 @@ public:
 			}()
 		} { }
 
+	// NOLINTNEXTLINE(modernize-use-equals-default)
 	~hklmRegistryKey_t() noexcept
 	{
 		// Close the key if we're destructing a valid object that holds a handle to one
@@ -75,6 +83,7 @@ public:
 	[[nodiscard]] bool valid() const noexcept { return handle != INVALID_HANDLE_VALUE; }
 
 	// Reads the string key `keyName` from the registry
+	// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 	[[nodiscard]] std::string readStringKey(std::string_view keyName) const
 	{
 		DWORD valueLength{0U};
@@ -213,12 +222,14 @@ serialInterface_t::serialInterface_t(const usbDevice_t &usbDevice) : device
 	static_cast<void>(ReadFile(device, serialState.data(), serialState.size(), nullptr, nullptr));
 }
 
+// NOLINTNEXTLINE(modernize-use-equals-default)
 serialInterface_t::~serialInterface_t() noexcept
 {
 	if (device != INVALID_HANDLE_VALUE)
 		CloseHandle(device);
 }
 
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 void serialInterface_t::handleDeviceError(const std::string_view operation) noexcept
 {
 	// Get the last error that occured
@@ -243,6 +254,7 @@ void serialInterface_t::swap(serialInterface_t &interface) noexcept
 	std::swap(device, interface.device);
 }
 
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 void serialInterface_t::writePacket(const std::string_view &packet) const
 {
 	console.debug("Remote write: "sv, packet);
@@ -257,6 +269,7 @@ void serialInterface_t::writePacket(const std::string_view &packet) const
 	}
 }
 
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 std::string serialInterface_t::readPacket() const
 {
 	std::array<char, bmp_t::maxPacketSize + 1U> packet{};

--- a/src/windows/serialInterface.cxx
+++ b/src/windows/serialInterface.cxx
@@ -170,13 +170,13 @@ serialInterface_t::serialInterface_t(const usbDevice_t &usbDevice) : device
 			// Try and open the node so we can start communications with the the device
 			return CreateFile
 			(
-				portName.c_str(),                               // UNC path to the target node
-				GENERIC_READ | GENERIC_WRITE,                   // Standard file permissions
-				0,                                              // With no sharing
-				nullptr,                                        // Default security attributes
-				OPEN_EXISTING,                                  // Only succeed if the node already exists
-				FILE_ATTRIBUTE_NORMAL | FILE_FLAG_NO_BUFFERING, // Normal but unbuffered I/O
-				nullptr                                         // No template file
+				portName.c_str(),                                // UNC path to the target node
+				GENERIC_READ | GENERIC_WRITE,                    // Standard file permissions
+				0,                                               // With no sharing
+				nullptr,                                         // Default security attributes
+				OPEN_EXISTING,                                   // Only succeed if the node already exists
+				FILE_ATTRIBUTE_NORMAL | FILE_FLAG_WRITE_THROUGH, // Normal I/O w/ write-through
+				nullptr                                          // No template file
 			);
 		}()
 	}

--- a/src/windows/serialInterface.cxx
+++ b/src/windows/serialInterface.cxx
@@ -222,9 +222,8 @@ serialInterface_t::serialInterface_t(const usbDevice_t &usbDevice) : device
 	if (!SetCommTimeouts(device, &timeouts))
 		handleDeviceError("set communications timeouts for device"sv);
 
-	// Having adjusted the line state, try to do a read of the serial state notification which will be sat in the buffer
-	std::array<uint8_t, 10U> serialState{};
-	static_cast<void>(ReadFile(device, serialState.data(), serialState.size(), nullptr, nullptr));
+	// Having adjusted the line state, discard anything sat in the receive buffer
+	PurgeComm(device, PURGE_RXCLEAR);
 }
 
 // NOLINTNEXTLINE(modernize-use-equals-default)

--- a/src/windows/serialInterface.cxx
+++ b/src/windows/serialInterface.cxx
@@ -214,11 +214,15 @@ serialInterface_t::serialInterface_t(const usbDevice_t &usbDevice) : device
 	}
 
 	COMMTIMEOUTS timeouts{};
-	timeouts.ReadIntervalTimeout = 10;
-	timeouts.ReadTotalTimeoutConstant = 10;
-	timeouts.ReadTotalTimeoutMultiplier = 10;
-	timeouts.WriteTotalTimeoutConstant = 10;
-	timeouts.WriteTotalTimeoutMultiplier = 10;
+	// Turn off read timeouts so that ReadFill() instantly returns even if there's no data waiting
+	// (we implement our own mechanism below for that case as we only want to wait if we get no data)
+	timeouts.ReadIntervalTimeout = MAXDWORD;
+	timeouts.ReadTotalTimeoutConstant = 0;
+	timeouts.ReadTotalTimeoutMultiplier = 0;
+	// Configure an exactly 100ms write timeout - we want this triggering to be fatal as something
+	// has gone very wrong if we ever hit this.
+	timeouts.WriteTotalTimeoutConstant = 100;
+	timeouts.WriteTotalTimeoutMultiplier = 0;
 	if (!SetCommTimeouts(device, &timeouts))
 		handleDeviceError("set communications timeouts for device"sv);
 


### PR DESCRIPTION
This PR is a port of the same speed improvement done to BMDA to reduce syscalls and improve remote protocol throughput. Due to a quirk on how the I/O code in this tool works, it also found a bug in the way the timeouts are configured which now needs backporting to BMDA too. It works in pretty much the same way as the BMDA version of this code, but is written in modern C++ instead.

Tested on Windows 10, this produces around a 1.6x speed up over the old code taking a 16MiB Flash read from 3m6s to 1m55s to complete on a i5 2520M laptop in a VM.