### PR TITLE
Fix: build and help

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -20,6 +20,7 @@ jobs:
       matrix:
         os:
           - { id: ubuntu-22.04, name: jammy }
+          - { id: ubuntu-24.04, name: noble }
         compiler:
           - 'clang-13'
           - 'clang-15'
@@ -27,6 +28,7 @@ jobs:
           - 'clang-17'
           - 'clang-18'
           - 'gcc-9'
+          - 'gcc-10'
           - 'gcc-11'
           - 'gcc-12'
           - 'gcc-13'

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -74,21 +74,20 @@ jobs:
           CC: ${{ matrix.compiler }}
         working-directory: ${{ runner.temp }}
       - name: Remove old LLVM 12 plugins
-        if: matrix.compiler != 'clang-12'
         run: |
-          sudo apt purge llvm-12-linker-tools
+          sudo apt purge llvm-12-linker-tools || true
       - name: Remove old LLVM 13 plugins
         if: matrix.compiler != 'clang-13'
         run: |
-          sudo apt purge llvm-13-linker-tools
+          sudo apt purge llvm-13-linker-tools || true
       - name: Remove old LLVM 14 plugins
         if: matrix.compiler != 'clang-14'
         run: |
-          sudo apt purge llvm-14-linker-tools
+          sudo apt purge llvm-14-linker-tools || true
       - name: Remove old LLVM 15 plugins
         if: matrix.compiler != 'clang-15'
         run: |
-          sudo apt purge llvm-15-linker-tools
+          sudo apt purge llvm-15-linker-tools || true
       - name: Install dependencies
         shell: bash
         run: sudo apt-get install libudev-dev

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -32,6 +32,14 @@ jobs:
           - 'gcc-11'
           - 'gcc-12'
           - 'gcc-13'
+        exclude:
+          # Exclude compilers that don't exist on the new LTS
+          - os: { id: ubuntu-24.04, name: noble }
+            compiler: 'clang-13'
+          - os: { id: ubuntu-24.04, name: noble }
+            compiler: 'clang-15'
+          - os: { id: ubuntu-24.04, name: noble }
+            compiler: 'clang-16'
       fail-fast: false
     env:
       BUILD_OPTS: ''
@@ -96,11 +104,15 @@ jobs:
         with:
           lfs: true
           submodules: true
-      - name: Setup Meson + Ninja + gcovr
+      - name: Upgrade pip + wheel
+        if: matrix.os.name == 'jammy'
         shell: bash
         run: |
           sudo python3 -m pip install --upgrade pip setuptools wheel
-          python3 -m pip install --user meson ninja gcovr
+      - name: Setup Meson + Ninja + gcovr
+        shell: bash
+        run: |
+          python3 -m pip install --break-system-packages --user meson ninja gcovr
         working-directory: ${{ runner.temp }}
       - name: Version tools
         shell: bash

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -25,6 +25,7 @@ jobs:
           - 'clang-15'
           - 'clang-16'
           - 'clang-17'
+          - 'clang-18'
           - 'gcc-9'
           - 'gcc-11'
           - 'gcc-12'
@@ -90,7 +91,7 @@ jobs:
         shell: bash
         run: sudo apt-get install libudev-dev
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: true
           submodules: true
@@ -127,14 +128,14 @@ jobs:
           ninja -C build coverage-xml
       - name: Upload failure logs
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: logs-${{ matrix.os.id }}-${{ matrix.compiler }}
           path: ${{ github.workspace }}/build/meson-logs/*
           retention-days: 5
       - name: Codecov
         if: success() && github.repository == 'blackmagic-debug/bmpflash' && matrix.compiler != 'clang-17'
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           directory: ./build/meson-logs/
           files: coverage.xml

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -103,8 +103,6 @@ jobs:
         os:
           - macos-latest
         compiler:
-          - gcc@9
-          - gcc@10
           - gcc@11
           - gcc@12
           - gcc@13 # needs hardcoding for the GCOV replacement

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -24,6 +24,7 @@ jobs:
         os:
           - macos-12
           - macos-13
+          - macos-14
         build_opts:
           - ''
         include:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os:
           - macos-12
-          - macos-11
+          - macos-13
         build_opts:
           - ''
         include:
@@ -41,7 +41,7 @@ jobs:
         run: |
           echo "GITHUB_WORKSPACE=`pwd`" >> $GITHUB_ENV
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: true
           submodules: true
@@ -75,14 +75,14 @@ jobs:
           ninja -C build coverage-xml
       - name: Upload failure logs
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: logs-${{ matrix.os }}-appleclang
           path: ${{ github.workspace }}/build/meson-logs/*
           retention-days: 5
       - name: Codecov
         if: success() && github.repository == 'blackmagic-debug/bmpflash'
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           directory: ./build/meson-logs/
           files: coverage.xml
@@ -100,9 +100,10 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-11
+          - macos-latest
         compiler:
           - gcc@9
+          - gcc@10
           - gcc@11
           - gcc@12
           - gcc@13 # needs hardcoding for the GCOV replacement
@@ -126,7 +127,7 @@ jobs:
         env:
           COMPILER: ${{ matrix.compiler }}
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: true
           submodules: true
@@ -162,14 +163,14 @@ jobs:
           ninja -C build coverage-xml
       - name: Upload failure logs
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: logs-${{ matrix.os }}-homebrew-${{ matrix.compiler }}
           path: ${{ github.workspace }}/build/meson-logs/*
           retention-days: 5
       - name: Codecov
         if: success() && github.repository == 'blackmagic-debug/bmpflash'
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           directory: ./build/meson-logs/
           files: coverage.xml

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -22,7 +22,6 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-12
           - macos-13
           - macos-14
         build_opts:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -43,7 +43,7 @@ jobs:
           arch: ${{ matrix.arch }}
       - name: Install OpenCppCoverage
         if: github.repository == 'blackmagic-debug/bmpflash'
-        uses: crazy-max/ghaction-chocolatey@v2.1.0
+        uses: crazy-max/ghaction-chocolatey@v3
         with:
           args: install OpenCppCoverage
       - name: Setup OpenCppCoverage
@@ -51,7 +51,7 @@ jobs:
         run: |
           echo "C:/Program Files/OpenCppCoverage" >> $env:GITHUB_PATH
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: true
           submodules: true
@@ -84,7 +84,7 @@ jobs:
           meson test -C build
       - name: Upload failure logs
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: logs-${{ matrix.os }}-${{ matrix.arch }}
           path: |
@@ -93,7 +93,7 @@ jobs:
           retention-days: 5
       - name: Codecov
         if: success() && github.repository == 'blackmagic-debug/bmpflash'
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -106,7 +106,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-2019
+          - windows-2022
         sys:
           - mingw64
           - ucrt64
@@ -139,7 +139,7 @@ jobs:
         run: |
           echo "GCOV=llvm-cov gcov" >> $GITHUB_ENV
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: true
           submodules: true
@@ -175,14 +175,14 @@ jobs:
           ninja -C build coverage-xml
       - name: Upload failure logs
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: logs-${{ matrix.os }}-${{ matrix.sys }}
           path: ${{ github.workspace }}/build/meson-logs/*
           retention-days: 5
       - name: Codecov
         if: success() && github.repository == 'blackmagic-debug/bmpflash'
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           directory: ./build/meson-logs/
           files: coverage.xml

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -16,7 +16,7 @@ jobs:
   build-windows:
     name: '${{ matrix.os }} (msvc ${{ matrix.arch }})'
     runs-on: ${{ matrix.os }}
-    if: false
+    # if: false
     strategy:
       matrix:
         os:

--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,7 @@ project(
 		'warning_level=3',
 		'buildtype=release',
 		'strip=true',
-		'b_debug=if-release',
+		'b_ndebug=if-release',
 		'b_lto=true',
  		# libusb needs to pass functions to/from C++ land
 		'cpp_eh=s',

--- a/src/bmpflash.cxx
+++ b/src/bmpflash.cxx
@@ -37,6 +37,20 @@ namespace bmpflash
 		console.writeln("This utility is licensed under BSD-3-Clause"sv);
 		console.writeln("Please report bugs to https://github.com/blackmagic-debug/bmpflash/issues"sv);
 	}
+
+	void displayActionHelp(const optionAlternation_t &action)
+	{
+		console.info("bmpflash - Black Magic Probe companion utility for SPI Flash provisioning and usage"sv);
+		console.writeln();
+		console.writeln("Usage:"sv);
+		console.writeln("\tbmpflash [options] "sv, action.displayName(), " [actionOptions]"sv);
+		console.writeln();
+		console.writeln("Action "sv, nullptr);
+		action.suboptions().displayHelp();
+		console.writeln();
+		console.writeln("This utility is licensed under BSD-3-Clause"sv);
+		console.writeln("Please report bugs to https://github.com/blackmagic-debug/bmpflash/issues"sv);
+	}
 }
 
 [[nodiscard]] auto findBMPs(const usbContext_t &context)
@@ -107,6 +121,18 @@ int main(const int argCount, const char *const *const argList)
 		return 1;
 	}
 	const auto &action{std::get<choice_t>(*actionArg)};
+
+	// Check if `-h`/`--help` was given for this action
+	if (action.arguments()["help"sv])
+	{
+		// It was, so find the right action option set and display its help
+		for (const auto &actionOptions : bmpflash::actions)
+		{
+			if (actionOptions.matches(action.value()))
+				bmpflash::displayActionHelp(actionOptions);
+		}
+		return 0;
+	}
 
 	// Get a libusb context to perform everything in
 	const usbContext_t context{};

--- a/src/bmpflash.cxx
+++ b/src/bmpflash.cxx
@@ -60,14 +60,7 @@ int main(const int argCount, const char *const *const argList)
 	console.showDebug(verbosity & 1U);
 
 	// Handle the version and help options first
-	const auto *const version{args["version"sv]};
-	const auto *const help{args["help"sv]};
-	if (version && help)
-	{
-		console.error("Can only specify one of --help and --version, not both."sv);
-		return 1;
-	}
-	if (version)
+	if (args["version"sv])
 	{
 		bmpflash::displayVersion();
 		const auto *const libusbVersion{libusb_get_version()};
@@ -76,7 +69,7 @@ int main(const int argCount, const char *const *const argList)
 		return 0;
 	}
 	// Display the help if requested or there were no command line options given
-	if (help || args.count() == 0U)
+	if (args["help"sv] || args.count() == 0U)
 	{
 		bmpflash::programOptions.displayHelp(args);
 		return 0;

--- a/src/bmpflash.cxx
+++ b/src/bmpflash.cxx
@@ -23,36 +23,6 @@ using substrate::commandLine::parseArguments;
 arguments_t args{};
 uint64_t verbosity{0U};
 
-namespace bmpflash
-{
-	void displayHelp() noexcept
-	{
-		console.info("bmpflash - Black Magic Probe companion utility for SPI Flash provisioning and usage"sv);
-		console.writeln();
-		console.writeln("Usage:"sv);
-		console.writeln("\tbmpflash [options] {action} [actionOptions]"sv);
-		console.writeln();
-		programOptions.displayHelp();
-		console.writeln();
-		console.writeln("This utility is licensed under BSD-3-Clause"sv);
-		console.writeln("Please report bugs to https://github.com/blackmagic-debug/bmpflash/issues"sv);
-	}
-
-	void displayActionHelp(const optionAlternation_t &action)
-	{
-		console.info("bmpflash - Black Magic Probe companion utility for SPI Flash provisioning and usage"sv);
-		console.writeln();
-		console.writeln("Usage:"sv);
-		console.writeln("\tbmpflash [options] "sv, action.displayName(), " [actionOptions]"sv);
-		console.writeln();
-		console.writeln("Action "sv, nullptr);
-		action.suboptions().displayHelp();
-		console.writeln();
-		console.writeln("This utility is licensed under BSD-3-Clause"sv);
-		console.writeln("Please report bugs to https://github.com/blackmagic-debug/bmpflash/issues"sv);
-	}
-}
-
 [[nodiscard]] auto findBMPs(const usbContext_t &context)
 {
 	std::vector<usbDevice_t> devices{};
@@ -108,7 +78,7 @@ int main(const int argCount, const char *const *const argList)
 	// Display the help if requested or there were no command line options given
 	if (help || args.count() == 0U)
 	{
-		bmpflash::displayHelp();
+		bmpflash::programOptions.displayHelp(args);
 		return 0;
 	}
 
@@ -117,7 +87,7 @@ int main(const int argCount, const char *const *const argList)
 	if (!actionArg)
 	{
 		console.error("Action to perform must be specified"sv);
-		bmpflash::displayHelp();
+		bmpflash::programOptions.displayHelp(args);
 		return 1;
 	}
 	const auto &action{std::get<choice_t>(*actionArg)};
@@ -125,12 +95,8 @@ int main(const int argCount, const char *const *const argList)
 	// Check if `-h`/`--help` was given for this action
 	if (action.arguments()["help"sv])
 	{
-		// It was, so find the right action option set and display its help
-		for (const auto &actionOptions : bmpflash::actions)
-		{
-			if (actionOptions.matches(action.value()))
-				bmpflash::displayActionHelp(actionOptions);
-		}
+		// Display the appropriate help
+		bmpflash::programOptions.displayHelp(args);
 		return 0;
 	}
 

--- a/src/include/options.hxx
+++ b/src/include/options.hxx
@@ -25,13 +25,21 @@ namespace bmpflash
 		return std::nullopt;
 	}
 
-	constexpr static auto serialOption
+	constexpr static auto baseOptions
 	{
-		option_t
-		{
-			optionFlagPair_t{"-s"sv, "--serial"sv},
-			"Use the BMP with the given, possibly partial, matching serial number"sv
-		}.takesParameter(optionValueType_t::string)
+		options
+		(
+			option_t
+			{
+				optionFlagPair_t{"-h"sv, "--help"sv},
+				"Display this help message and exit"sv
+			}.exclusive(),
+			option_t
+			{
+				optionFlagPair_t{"-s"sv, "--serial"sv},
+				"Use the BMP with the given, possibly partial, matching serial number"sv
+			}.takesParameter(optionValueType_t::string)
+		)
 	};
 
 	constexpr static auto fileOption
@@ -43,13 +51,11 @@ namespace bmpflash
 		}.takesParameter(optionValueType_t::path).required()
 	};
 
-	constexpr static auto probeOptions{options(serialOption)};
-
 	constexpr static auto deviceOptions
 	{
 		options
 		(
-			serialOption,
+			baseOptions,
 			option_t
 			{
 				optionFlagPair_t{"-b"sv, "--bus"sv},
@@ -72,7 +78,7 @@ namespace bmpflash
 		)
 	};
 
-	constexpr static auto provisioningOptions{options(serialOption, fileOption)};
+	constexpr static auto provisioningOptions{options(baseOptions, fileOption)};
 	constexpr static auto generalFlashOptions{options(deviceOptions, fileOption)};
 
 	constexpr static auto actions
@@ -82,7 +88,7 @@ namespace bmpflash
 			{
 				"info"sv,
 				"Display information about attached Black Magic Probes"sv,
-				probeOptions,
+				baseOptions,
 			},
 			{
 				"sfdp"sv,

--- a/src/include/options.hxx
+++ b/src/include/options.hxx
@@ -25,21 +25,13 @@ namespace bmpflash
 		return std::nullopt;
 	}
 
-	constexpr static auto baseOptions
+	constexpr static auto serialOption
 	{
-		options
-		(
-			option_t
-			{
-				optionFlagPair_t{"-h"sv, "--help"sv},
-				"Display this help message and exit"sv
-			}.exclusive(),
-			option_t
-			{
-				optionFlagPair_t{"-s"sv, "--serial"sv},
-				"Use the BMP with the given, possibly partial, matching serial number"sv
-			}.takesParameter(optionValueType_t::string)
-		)
+		option_t
+		{
+			optionFlagPair_t{"-s"sv, "--serial"sv},
+			"Use the BMP with the given, possibly partial, matching serial number"sv
+		}.takesParameter(optionValueType_t::string)
 	};
 
 	constexpr static auto fileOption
@@ -51,11 +43,13 @@ namespace bmpflash
 		}.takesParameter(optionValueType_t::path).required()
 	};
 
+	constexpr static auto probeOptions{options(serialOption)};
+
 	constexpr static auto deviceOptions
 	{
 		options
 		(
-			baseOptions,
+			serialOption,
 			option_t
 			{
 				optionFlagPair_t{"-b"sv, "--bus"sv},
@@ -78,7 +72,7 @@ namespace bmpflash
 		)
 	};
 
-	constexpr static auto provisioningOptions{options(baseOptions, fileOption)};
+	constexpr static auto provisioningOptions{options(probeOptions, fileOption)};
 	constexpr static auto generalFlashOptions{options(deviceOptions, fileOption)};
 
 	constexpr static auto actions
@@ -88,7 +82,7 @@ namespace bmpflash
 			{
 				"info"sv,
 				"Display information about attached Black Magic Probes"sv,
-				baseOptions,
+				probeOptions,
 			},
 			{
 				"sfdp"sv,
@@ -115,14 +109,25 @@ namespace bmpflash
 
 	constexpr static auto programOptions
 	{
-		options
-		(
-			option_t{optionFlagPair_t{"-h"sv, "--help"sv}, "Display this help message and exit"sv},
-			option_t{"--version"sv, "Display the program version information and exit"sv},
-			option_t{optionFlagPair_t{"-v"sv, "--verbosity"sv}, "Set the program output verbosity"sv}
-				.takesParameter(optionValueType_t::unsignedInt).valueRange(0U, 1U),
-			optionSet_t{"action"sv, actions}
-		)
+		optionsRoot_t
+		{
+			options
+			(
+				option_t{optionFlagPair_t{"-h"sv, "--help"sv}, "Display this help message and exit"sv}
+					.exclusive().global(),
+				option_t{"--version"sv, "Display the program version information and exit"sv}.exclusive(),
+				option_t{optionFlagPair_t{"-v"sv, "--verbosity"sv}, "Set the program output verbosity"sv}
+					.takesParameter(optionValueType_t::unsignedInt).valueRange(0U, 1U),
+				optionSet_t{"action"sv, actions}
+			)
+		}
+			.helpHeader("bmpflash - Black Magic Probe companion utility for SPI Flash provisioning and usage"sv)
+			.usage("bmpflash [options] {action} [actionOptions]"sv)
+			.helpFooter
+			(
+				"This utility is licensed under BSD-3-Clause\n"
+				"Please report bugs to https://github.com/blackmagic-debug/bmpflash/issues"sv
+			)
 	};
 } // namespace bmpflash
 


### PR DESCRIPTION
In this PR we do two things: We fix the build which is broken by an improper project option; and implement better, more discoverable, help care of some companion changes in substrate.

For the first part of this, the `project()` statement in the top-level meson.build had `b_debug` as an option specified which is wrong - the option is actually called `b_ndebug`.

For the second part, we have introduced a new optionsRoot_t to the substrate command line parser types, and implemented a whole lot more help generation machinery which allows it to generate the full help text automatically. This is then backed by companion changes here to make use of the new types and machinery to provide help text generation for cheap while also properly recursing into option set alternations so that the user can get action-specific help as well.

The `-h`/`--help` option is now a global option with this, meaning it is allowed to appear at every level of parsing.